### PR TITLE
fix: background not checked right useEnvironment

### DIFF
--- a/src/core/abstractions/useEnvironment/index.ts
+++ b/src/core/abstractions/useEnvironment/index.ts
@@ -64,7 +64,7 @@ export async function useEnvironment({
 
   if (state.scene) {
     state.scene.environment = texture
-    if (background !== undefined) {
+    if (background) {
       state.scene.background = texture
     }
     if (blur) {


### PR DESCRIPTION
useEnvironment composable isn't checking the background property correctly. Since it's checking if it is not equal to undefined, and it always defaults to false, the scene background will always be set. This PR adjusts it so the background will only set if the property is truthy. 

Example of the bug here: https://stackblitz.com/edit/tresjs-basic-pvijjg?file=src%2Fcomponents%2FTheExperience.vue
