### PR TITLE
chore: fix linter warning

### DIFF
--- a/playground/src/pages/CameraControlsDemo.vue
+++ b/playground/src/pages/CameraControlsDemo.vue
@@ -86,7 +86,8 @@ function onEnd() {
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
-    <CameraControls v-bind="controlsState" ref="controlsRef" make-default @change="onChange" @start="onStart" @end="onEnd" />
+    <CameraControls v-bind="controlsState" ref="controlsRef" make-default @change="onChange" @start="onStart"
+      @end="onEnd" />
     <TresGridHelper :position="[0, -1, 0]" />
     <TresMesh ref="boxMeshRef">
       <TresBoxGeometry :args="[2, 2, 2]" />


### PR DESCRIPTION
## Problem

````
$ pnpm run lint
> ./cientos/playground/src/pages/CameraControlsDemo.vue
> 89:1  warning  This line has a length of 125. Maximum allowed is 120  max-len 
````

## Solution

Broke line 89.

### Note

The contribution docs say you accept PRs for spelling mistakes and that PRs should be linted before submitting, so I don't think this is out of place, but feel free to close if it is.