### PR TITLE
fix(cientos): controls' props priority

### DIFF
--- a/src/core/controls/CameraControls.vue
+++ b/src/core/controls/CameraControls.vue
@@ -412,7 +412,7 @@ defineExpose({
 
 <template>
   <TresCameraControls
-    v-if="activeCamera && renderer"
+    v-if="(camera || activeCamera) && (domElement || renderer)"
     ref="controlsRef"
     :min-polar-angle="minPolarAngle"
     :max-polar-angle="maxPolarAngle"
@@ -438,6 +438,6 @@ defineExpose({
     :boundary-friction="boundaryFriction"
     :rest-threshold="restThreshold"
     :collider-meshes="colliderMeshes"
-    :args="[activeCamera || camera, renderer?.domElement || domElement]"
+    :args="[camera || activeCamera, domElement || renderer.domElement]"
   />
 </template>

--- a/src/core/controls/MapControls.vue
+++ b/src/core/controls/MapControls.vue
@@ -60,8 +60,8 @@ onUnmounted(() => {
 
 <template>
   <TresMapControls
-    v-if="activeCamera && renderer"
+    v-if="(camera || activeCamera) && (domElement || renderer)"
     ref="controlsRef"
-    :args="[activeCamera || camera, renderer?.domElement || domElement]"
+    :args="[camera || activeCamera, domElement || renderer.domElement]"
   />
 </template>

--- a/src/core/controls/OrbitControls.vue
+++ b/src/core/controls/OrbitControls.vue
@@ -319,7 +319,7 @@ onUnmounted(() => {
 
 <template>
   <TresOrbitControls
-    v-if="activeCamera && renderer"
+    v-if="(camera || activeCamera) && (domElement || renderer)"
     ref="controlsRef"
     :target="target"
     :auto-rotate="autoRotate"
@@ -342,6 +342,6 @@ onUnmounted(() => {
     :zoom-speed="zoomSpeed"
     :enable-rotate="enableRotate"
     :rotate-speed="rotateSpeed"
-    :args="[activeCamera || camera, renderer?.domElement || domElement]"
+    :args="[camera || activeCamera, domElement || renderer.domElement]"
   />
 </template>

--- a/src/core/controls/PointerLockControls.vue
+++ b/src/core/controls/PointerLockControls.vue
@@ -91,8 +91,8 @@ defineExpose({
 
 <template>
   <TresPointerLockControls
-    v-if="activeCamera && renderer"
+    v-if="(camera || activeCamera) && (domElement || renderer)"
     ref="controlsRef"
-    :args="[activeCamera || camera, renderer?.domElement || domElement]"
+    :args="[camera || activeCamera, domElement || renderer.domElement]"
   />
 </template>


### PR DESCRIPTION
It appears that the `domElement` and the `camera` props cannot be overwritten in `Controls` components. This PR fixes it.