### PR TITLE
fix(Levioso): changing speed causes jerkiness

### DIFF
--- a/src/core/abstractions/Levioso.vue
+++ b/src/core/abstractions/Levioso.vue
@@ -27,15 +27,16 @@ defineExpose({
 const { onLoop } = useRenderLoop()
 
 const offset = ref(Math.random() * 10000)
-
-onLoop(({ elapsed }) => {
+let elapsed = 0
+onLoop(({ delta }) => {
   if (!groupRef.value) return
 
+  elapsed += delta * props.speed * 0.25
   const theta = offset.value + elapsed
-  groupRef.value.rotation.x = (Math.cos((theta / 4) * props.speed) / 8) * props.rotationFactor
-  groupRef.value.rotation.y = (Math.sin((theta / 4) * props.speed) / 8) * props.rotationFactor
-  groupRef.value.rotation.z = (Math.sin((theta / 4) * props.speed) / 20) * props.rotationFactor
-  let yPosition = Math.sin((theta / 4) * props.speed) / 10
+  groupRef.value.rotation.x = (Math.cos(theta) / 8) * props.rotationFactor
+  groupRef.value.rotation.y = (Math.sin(theta) / 8) * props.rotationFactor
+  groupRef.value.rotation.z = (Math.sin(theta) / 20) * props.rotationFactor
+  let yPosition = Math.sin(theta) / 10
   yPosition = MathUtils.mapLinear(yPosition, -0.1, 0.1, props.range?.[0] ?? -0.1, props.range?.[1] ?? 0.1)
   groupRef.value.position.y = yPosition * props.floatFactor
 })

--- a/src/core/abstractions/Levioso.vue
+++ b/src/core/abstractions/Levioso.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useRenderLoop } from '@tresjs/core'
 import { MathUtils } from 'three'
-import { ref, shallowRef } from 'vue'
+import { shallowRef } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -26,13 +26,14 @@ defineExpose({
 
 const { onLoop } = useRenderLoop()
 
-const offset = ref(Math.random() * 10000)
-let elapsed = 0
+const offset = Math.random() * 10000
+let elapsed = offset
+const SPEED_SCALE = 0.25
 onLoop(({ delta }) => {
   if (!groupRef.value) return
 
-  elapsed += delta * props.speed * 0.25
-  const theta = offset.value + elapsed
+  elapsed += delta * props.speed * SPEED_SCALE
+  const theta = elapsed
   groupRef.value.rotation.x = (Math.cos(theta) / 8) * props.rotationFactor
   groupRef.value.rotation.y = (Math.sin(theta) / 8) * props.rotationFactor
   groupRef.value.rotation.z = (Math.sin(theta) / 20) * props.rotationFactor

--- a/src/core/abstractions/Levioso.vue
+++ b/src/core/abstractions/Levioso.vue
@@ -24,23 +24,34 @@ defineExpose({
   value: groupRef,
 })
 
-const { onLoop } = useRenderLoop()
+{
+  const PERIOD_SCALE = 1 / 4
+  const AMPLITUDE_ROTATION_X = 1 / 8
+  const AMPLITUDE_ROTATION_Y = 1 / 8
+  const AMPLITUDE_ROTATION_Z = 1 / 20
+  const START_OFFSET = Math.random() * 10000
 
-const offset = Math.random() * 10000
-let elapsed = offset
-const SPEED_SCALE = 0.25
-onLoop(({ delta }) => {
-  if (!groupRef.value) return
+  const { onLoop } = useRenderLoop()
+  let elapsed = START_OFFSET
 
-  elapsed += delta * props.speed * SPEED_SCALE
-  const theta = elapsed
-  groupRef.value.rotation.x = (Math.cos(theta) / 8) * props.rotationFactor
-  groupRef.value.rotation.y = (Math.sin(theta) / 8) * props.rotationFactor
-  groupRef.value.rotation.z = (Math.sin(theta) / 20) * props.rotationFactor
-  let yPosition = Math.sin(theta) / 10
-  yPosition = MathUtils.mapLinear(yPosition, -0.1, 0.1, props.range?.[0] ?? -0.1, props.range?.[1] ?? 0.1)
-  groupRef.value.position.y = yPosition * props.floatFactor
-})
+  onLoop(({ delta }) => {
+    if (!groupRef.value) return
+
+    elapsed += delta * props.speed
+    const theta = elapsed * PERIOD_SCALE
+
+    const group = groupRef.value
+    group.rotation.x = Math.cos(theta) * AMPLITUDE_ROTATION_X * props.rotationFactor
+    group.rotation.y = Math.sin(theta) * AMPLITUDE_ROTATION_Y * props.rotationFactor
+    group.rotation.z = Math.sin(theta) * AMPLITUDE_ROTATION_Z * props.rotationFactor
+    group.position.y = MathUtils.mapLinear(
+      Math.sin(theta), 
+      -1, 
+      1, 
+      props.range?.[0] ?? -0.1, 
+      props.range?.[1] ?? 0.1) * props.floatFactor
+  })
+}
 </script>
 
 <template>

--- a/src/core/abstractions/Levioso.vue
+++ b/src/core/abstractions/Levioso.vue
@@ -44,12 +44,7 @@ defineExpose({
     group.rotation.x = Math.cos(theta) * AMPLITUDE_ROTATION_X * props.rotationFactor
     group.rotation.y = Math.sin(theta) * AMPLITUDE_ROTATION_Y * props.rotationFactor
     group.rotation.z = Math.sin(theta) * AMPLITUDE_ROTATION_Z * props.rotationFactor
-    group.position.y = MathUtils.mapLinear(
-      Math.sin(theta), 
-      -1, 
-      1, 
-      props.range?.[0] ?? -0.1, 
-      props.range?.[1] ?? 0.1) * props.floatFactor
+    group.position.y = MathUtils.mapLinear(Math.sin(theta), -1, 1, props.range[0], props.range[1]) * props.floatFactor
   })
 }
 </script>


### PR DESCRIPTION
Closes #208

## Before (`speed` scales `elapsed`):

https://github.com/Tresjs/cientos/assets/20469369/01627092-cb86-4b94-99fe-6462adf418e0

## After (`speed` scales `delta`):

https://github.com/Tresjs/cientos/assets/20469369/38646d60-1d20-4f53-b332-fe10ca391c2e

## Refactors

I took the initiative to do a few refactors, each in separate commits:

* Removing an unexposed, unchanging `ref`: `offset`
* Extracting and naming constants, and "hiding" them in a closure
* Removing some nullish checks on `props.range`

Please especially have a look at the last one:

`props.range` is assigned a default value. It seems to me that it can't be `null` or `undefined`. It's typed as `[number, number]`, so the type checker should signal an error, e.g., if `:range="[1]"`.

The other `props` fields don't have null checks.

So I removed the null checks on `props.range`, but maybe I'm missing something.

Thanks!