### PR TITLE
docs: fix minor typos, phrasing, outdated props

### DIFF
--- a/docs/guide/abstractions/lensflare.md
+++ b/docs/guide/abstractions/lensflare.md
@@ -60,7 +60,7 @@ If you set a `seed` but not `seedProps`, the component will fall back to the def
 
 ### Example
 
-```
+```vue
 <Lensflare :seed="seedRef" />
 ```
 

--- a/docs/guide/abstractions/levioso.md
+++ b/docs/guide/abstractions/levioso.md
@@ -6,7 +6,7 @@
 
 ![Leviosa](https://media.giphy.com/media/HaCFT5ghY6L1m/giphy.gif)
 
-The `cientos` package provides a `<Levioso />` wrapper that makes it content... float, just like Magic 🪄✨
+The `cientos` package provides a `<Levioso />` wrapper that makes its content … float, just like Magic 🪄✨
 
 ## Usage
 

--- a/docs/guide/abstractions/mouse-parallax.md
+++ b/docs/guide/abstractions/mouse-parallax.md
@@ -8,7 +8,7 @@
 
 ## Usage
 
-You only need import it and add it to your template as `<MouseParallax />`. Additionally, you can pass the following props.
+You only need to import it and add it to your template as `<MouseParallax />`. Additionally, you can pass the following props:
 
 `factor` is a number to increase the movement range of the camera. `ease` is a number that smoothes the movement. You can also disable the effect with the `disabled` prop.
 

--- a/docs/guide/abstractions/mouse-parallax.md
+++ b/docs/guide/abstractions/mouse-parallax.md
@@ -4,13 +4,13 @@
   <MouseParallaxDemo />
 </DocsDemo>
 
-`<MouseParallax />` is a component that allow you to create easily the pam parallax effect. The camera will update automatically according to the mouse position, creating a beautiful nice effect
+`<MouseParallax />` is a component that allows you to easily create a [parallax](https://en.wikipedia.org/wiki/Parallax) effect. The camera will update automatically according to the mouse position.
 
 ## Usage
 
-You only need import it and use it `<MouseParallax />` additionally you can pass two props, ease and factor.
+You only need import it and add it to your template as `<MouseParallax />`. Additionally, you can pass the following props.
 
-Factor is a number to increase the movement range of the camera and ease it's a boolean that create a smooth transition. Also you can disabled with the "disable" prop
+`factor` is a number to increase the movement range of the camera. `ease` is a number that smoothes the movement. You can also disable the effect with the `disabled` prop.
 
 ```vue
 <template>
@@ -30,6 +30,6 @@ Factor is a number to increase the movement range of the camera and ease it's a 
 
 | Prop         | Description                                             | Default |
 | :----------- | :------------------------------------------------------ | ------- |
-| **disabled** | enable or disabled the effect, boolean                  | false   |
-| **factor**   | Increase the range of the parallax | 2.5       |
-| **ease-factor**   | enable or disabled the easing effect | true       |
+| **disabled** | Enable or disable the effect                            | false   |
+| **factor**   | Increase the range of the parallax                      | 2.5     |
+| **ease**     | Increase the camera movement speed                      | 0.1     |

--- a/docs/guide/abstractions/text-3d.md
+++ b/docs/guide/abstractions/text-3d.md
@@ -1,6 +1,6 @@
 # Text3D
 
-`<Text3D />` is a component that renders a 3D text. It is a wrapper around the [TextGeometry](https://threejs.org/docs/#api/en/geometries/TextGeometry) class.
+`<Text3D />` is a component that renders text in 3D. It is a wrapper around the [TextGeometry](https://threejs.org/docs/#api/en/geometries/TextGeometry) class.
 
 <DocsDemo>
   <Text3Demo />

--- a/docs/guide/controls/camera-controls.md
+++ b/docs/guide/controls/camera-controls.md
@@ -14,7 +14,9 @@ The `cientos` package provides a component called `<CameraControls />` that is a
 The nicest part? You don't need to extend the catalog or pass any arguments.
 It just works. 💯
 
-```vue{3}
+## Usage
+
+```vue{4}
 <template>
   <TresCanvas shadows alpha>
     <TresPerspectiveCamera :args="[45, 1, 0.1, 1000]" />
@@ -63,7 +65,7 @@ Certainly! Here's the properties of the object in raw markdown table format:
 
 ## Events
 
-```html
+```vue
 <CameraControls @change="onChange" @start="onStart" @end="onEnd" />
 ```
 

--- a/docs/guide/controls/keyboard-controls.md
+++ b/docs/guide/controls/keyboard-controls.md
@@ -2,18 +2,19 @@
 
 KeyboardControls is a special type of controller that allows you to move using your keyboard.
 
-## In combination with PointerLockControls.
+## Usage
+
+### In combination with PointerLockControls
 
 Here you need to use the PointerLockControls with make-default props, KeyboardControls will automatically adapt to it, creating a really good effect first player experiences.
 
-```vue{3}
+```vue{5}
 <template>
   <TresCanvas shadows alpha>
     <TresPerspectiveCamera :position="[0, 0, 3]" />
     <PointerLockControls make-default  />
     <KeyboardControls />
     <TresGridHelper :args="[10, 10]" />
-
   </TresCanvas>
 </template>
 ```
@@ -24,20 +25,19 @@ Just by doing this, works great but in addition the TresJs team give some specia
 - Jump: to jump
 - gravity: to control the gravity related to the jump
 
-## In combination with slots.
+### In combination with slots
 
 Here you can move meshes by using your keyboard, by default you move through the X and Z axis, but you can change it with the is2D prop, to move your meshes on the X and Y axis
 
-```vue{3}
+```vue{4-8}
 <template>
   <TresCanvas shadows alpha>
     <TresPerspectiveCamera :position="[0, 0, 3]" />
-    <KeyboardControls >
+    <KeyboardControls>
       <Sphere>
         <TresMeshNormalMaterial />
       </Sphere>
     </KeyboardControls>
-
   </TresCanvas>
 </template>
 ```

--- a/docs/guide/controls/map-controls.md
+++ b/docs/guide/controls/map-controls.md
@@ -14,16 +14,18 @@ The `cientos` package provides a component called `<MapControls />`, which is a 
 The nicest part? You don't need to extend the catalog or pass any arguments.
 It just works. 💯
 
-```vue{3}
+## Usage
+
+```vue{4}
 <template>
   <TresCanvas shadows alpha>
     <TresPerspectiveCamera :position="[0, 0, 3]" />
     <MapControls />
     <TresGridHelper :args="[10, 10]" />
-
   </TresCanvas>
 </template>
 ```
+
 ::: warning
 Is really important that the Perspective camera is set first in the canvas. Otherwise might break.
 :::

--- a/docs/guide/controls/orbit-controls.md
+++ b/docs/guide/controls/orbit-controls.md
@@ -15,12 +15,13 @@ The `cientos` package provides a component called `<OrbitControls />` that is a 
 The nicest part? You don't need to extend the catalog or pass any arguments.  
 It just works. 💯
 
-```vue{3}
+## Usage
+
+```vue{4}
 <template>
   <TresCanvas shadows alpha>
     <TresPerspectiveCamera :args="[45, 1, 0.1, 1000]" />
     <OrbitControls />
-
   </TresCanvas>
 </template>
 ```
@@ -61,7 +62,7 @@ Is really important that the Perspective camera is set first in the canvas. Othe
 
 ## Events
 
-```html
+```vue
 <OrbitControls @change="onChange" @start="onStart" @end="onEnd" />
 ```
 

--- a/docs/guide/controls/pointer-lock-controls.md
+++ b/docs/guide/controls/pointer-lock-controls.md
@@ -15,7 +15,9 @@ This control uses the [Pointer Lock API](https://developer.mozilla.org/en-US/doc
 In addition, you need to wait 1 second between canceling and re-starting the event
 :::
 
-```vue{3}
+## Usage
+
+```vue{4}
 <template>
   <TresCanvas shadows alpha>
     <TresPerspectiveCamera :position="[0, 0, 3]" />

--- a/docs/guide/controls/scroll-controls.md
+++ b/docs/guide/controls/scroll-controls.md
@@ -8,9 +8,11 @@
 
 The `cientos` package create this controls from scratch for you, and comes with really useful props to customize your experiences, try it out. ✨
 
+## Usage
+
 To start using it, you just need to import it and play with it.
 
-```vue{3}
+```vue{4}
 <template>
   <TresCanvas window-size>
     <TresPerspectiveCamera :position="[0, 0, 3]" />
@@ -26,7 +28,7 @@ Is really important that the Perspective camera is set first in the canvas. Othe
 
 By default `ScrollControls` creates a scroll around the canvas and takes the camera as a default for animate, also it comes with a reactive `progress` param that returns a normalized value from 0 (start point) to 1 (end point) you just need to attach it to a v-model.
 
-```vue{3}
+```vue{2-5,10}
 <script setup>
 const progress = ref(0) // it will return a normalized number from 0 to 1
 watchEffect(() => {
@@ -44,7 +46,7 @@ watchEffect(() => {
 
 You can use the `horizontal` prop, to makes the scroll horizontal way,.
 
-```vue{3}
+```vue{4}
 <template>
   <TresCanvas window-size>
     <TresPerspectiveCamera :position="[0, 0, 3]" />
@@ -56,7 +58,7 @@ You can use the `horizontal` prop, to makes the scroll horizontal way,.
 
 With the `pages` prop you can control the length of the scroll, and with the `distance` you can control how much movement is apply to the objects ( you can for example use it with 0 value and use the progress element)
 
-```vue{3}
+```vue{4-8}
 <template>
   <TresCanvas window-size> // 
     <TresPerspectiveCamera :position="[0, 0, 3]" />
@@ -72,7 +74,7 @@ With the `pages` prop you can control the length of the scroll, and with the `di
 
 But it's not all, you can also pass the `htmlScroll` props and deactivate the custom scroll and use the native html scroll.
 
-```vue{3}
+```vue{5}
 <template>
 <div style="height="200vh"></div> //
   <TresCanvas window-size>
@@ -88,11 +90,11 @@ But it's not all, you can also pass the `htmlScroll` props and deactivate the cu
 - The `htmlScroll` will set the TresCanvas as a fixed background.
 :::
 
-## Slots
+### Slots
 
-the elements that you pass as a slot will be affected by the scroll effect, and follow the camera
+The elements that you pass as a slot will be affected by the scroll effect, and follow the camera.
 
-```vue{3}
+```vue{5-7}
 <template>
 <div style="height="200vh"></div> //
   <TresCanvas window-size>

--- a/docs/guide/controls/transform-controls.md
+++ b/docs/guide/controls/transform-controls.md
@@ -41,7 +41,7 @@ The Transform Controls can be used in three different modes:
 
 The default mode allows you to move the object around the scene.
 
-```html
+```vue
 <TransformControls mode="translate" :object="sphereRef" />
 ```
 
@@ -51,7 +51,7 @@ The default mode allows you to move the object around the scene.
 
 The rotate mode allows you to rotate the object around the scene.
 
-```html
+```vue
 <TransformControls mode="rotate" :object="boxRef" />
 ```
 
@@ -61,7 +61,7 @@ The rotate mode allows you to rotate the object around the scene.
 
 The scale mode allows you to scale the object around the scene.
 
-```html
+```vue
 <TransformControls mode="scale" :object="sphereRef" />
 ```
 

--- a/docs/guide/directives/v-always-look-at.md
+++ b/docs/guide/directives/v-always-look-at.md
@@ -2,7 +2,9 @@
 
 With the new directive v-always-look-at provided by **TresJS**, you can add easily command an [Object3D](https://threejs.org/docs/index.html?q=object#api/en/core/Object3D) to always look at a specific position, this could be passed as a Vector3 or an Array.
 
-```vue{3}
+## Usage
+
+```vue{3,9}
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
 import { Box, vAlwaysLookAt } from '@tresjs/cientos'
@@ -24,11 +26,11 @@ You could ask, this is fine but I can use the :look-at method directly in the co
 
 The answers is that with the method :look-at you will indicated to look at that position just once, when the instance is mounted, then if the object changes this will not get updated
 
-## You can look at other instance too!
+### You can look at other instance too!
 
 Another advantage is that you can look at an instance in movement, for example with the camera, like so:
 
-```vue{3}
+```vue{4,6,20,23}
 <script setup lang="ts">
 import { shallowRef } from 'vue'
 import { TresCanvas, useRenderLoop } from '@tresjs/core'
@@ -49,11 +51,11 @@ onLoop(({ elapsed }) => {
     <TresCanvas >
       <TresPerspectiveCamera :position="[0, 2, 5]"
         v-always-look-at="sphereRef"
-       />
+      />
       <Sphere
-         ref="sphereRef"
-         :scale="0.5"
-       />
+        ref="sphereRef"
+        :scale="0.5"
+      />
   </TresCanvas>
 </template>
 ```

--- a/docs/guide/directives/v-light-helper.md
+++ b/docs/guide/directives/v-light-helper.md
@@ -2,7 +2,9 @@
 
 With the new directive v-light-helper provided by **TresJS**, you can add fast the respective helper to your lights with just one line of code 😍.
 
-```vue{3}
+## Usage
+
+```vue{2,8,11,14,17}
 <script setup lang="ts">
 import { OrbitControls, Sphere, vLightHelper } from '@tresjs/cientos'
 </script>
@@ -18,7 +20,6 @@ import { OrbitControls, Sphere, vLightHelper } from '@tresjs/cientos'
       <TresSpotLight
         v-light-helper
       />
-
       <TresHemisphereLight
         v-light-helper
       />

--- a/docs/guide/directives/v-log.md
+++ b/docs/guide/directives/v-log.md
@@ -4,7 +4,7 @@
 
 When you have to log your instance you have to use the template reference and then log them:
 
-```vue{3}
+```vue
 <script setup lang="ts">
 import { shallowRef, watch } from 'vue'
 
@@ -28,11 +28,11 @@ watch(sphereRef, value => {
 
 And is A LOT of code just for a simple log right?
 
-## Solution
+## Usage
 
 With the new directive v-log provided by **TresJS**, you can do this by just adding `v-log` to the instance.
 
-```vue{3}
+```vue{2,10,12}
 <script setup lang="ts">
 import { OrbitControls, Sphere, vLog } from '@tresjs/cientos'
 </script>

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -9,7 +9,7 @@ The `cientos` package uses [`three-stdlib`](https://github.com/pmndrs/three-stdl
 It just works. 💯
 
 ::: info
-This package is not required to use the core library, but they can make your DX way better, specially for complex scenes.
+This package is not required to use the core library, but it improves DX, especially for complex scenes.
 :::
 
 ## Installation

--- a/docs/guide/loaders/fbx-model.md
+++ b/docs/guide/loaders/fbx-model.md
@@ -6,6 +6,8 @@
 
 The `FBXModel` component is a wrapper around [`useFBX`](./use-fbx.md) composable and accepts the same options as props.
 
+## Usage
+
 ```vue{2,9}
 <script setup lang="ts">
 import { OrbitControls, FBXModel } from '@tresjs/cientos'

--- a/docs/guide/loaders/gltf-model.md
+++ b/docs/guide/loaders/gltf-model.md
@@ -6,6 +6,8 @@
 
 The `GLTFModel` component is a wrapper around [`useGLTF`](./use-gltf.md) composable and accepts the same options as props.
 
+## Usage
+
 ```vue{2,9}
 <script setup lang="ts">
 import { OrbitControls, GLTFModel } from '@tresjs/cientos'
@@ -26,7 +28,7 @@ import { OrbitControls, GLTFModel } from '@tresjs/cientos'
 
 You can access the model reference by passing a `ref` to the `model` prop and then using to get the object.
 
-```vue{3,6}
+```ts
 <script setup lang="ts">
 import { OrbitControls, GLTFModel } from '@tresjs/cientos'
 

--- a/docs/guide/loaders/use-fbx.md
+++ b/docs/guide/loaders/use-fbx.md
@@ -16,7 +16,7 @@ const model = await useFBX('/models/Jeep.fbx')
 
 Then is as straightforward as adding the scene to your scene:
 
-```html{3}
+```vue{3}
 <TresCanvas shadows alpha>
   <Suspense>
     <primitive :object="scene" />

--- a/docs/guide/loaders/use-gltf.md
+++ b/docs/guide/loaders/use-gltf.md
@@ -16,7 +16,7 @@ const { scene } = await useGLTF('/models/AkuAku.gltf')
 
 Then is as straightforward as adding the scene to your scene:
 
-```html{3}
+```vue{3}
 <TresCanvas shadows alpha>
   <Suspense>
     <primitive :object="scene" />

--- a/docs/guide/loaders/use-progress.md
+++ b/docs/guide/loaders/use-progress.md
@@ -14,7 +14,7 @@ const { hasFinishLoading, progress, items } = await useProgress()
 
 Then you can use the `progress` value to show a loading bar or a spinner:
 
-```html
+```vue
 <template>
   <Transition
     name="fade-overlay"

--- a/docs/guide/materials/glass-material.md
+++ b/docs/guide/materials/glass-material.md
@@ -10,7 +10,7 @@ The `cientos` package provides a new`<MeshGlassMaterial />` component that makes
 
 ### You can use it like you normally do with TresJs
 
-```html
+```vue{3}
 <TresMesh>
   <TresTorusGeometry />
   <MeshGlassMaterial />
@@ -19,7 +19,7 @@ The `cientos` package provides a new`<MeshGlassMaterial />` component that makes
 
 ### You can also replace the material of an existing mesh like this:
 
-```vue{3}
+```vue{4,6-15,20}
 <script setup lang="ts">
 import { ref, shallowRef, watch } from 'vue'
 import { TresCanvas } from '@tresjs/core'
@@ -46,7 +46,7 @@ watch(glassMaterialRef, value => {
     <TresBoxGeometry />
     <MeshBasicMaterial  />
   </TresMesh>
-</template
+</template>
 ```
 ## Tips
 

--- a/docs/guide/materials/wobble-material.md
+++ b/docs/guide/materials/wobble-material.md
@@ -11,7 +11,7 @@ The `cientos` package provides a `<MeshWobbleMaterial />` component that makes a
 
 ## Usage
 
-```html
+```vue
 <TresMesh>
   <TresTorusGeometry />
   <MeshWobbleMaterial color="orange" speed="10" factor="5" />

--- a/docs/guide/misc/stats.md
+++ b/docs/guide/misc/stats.md
@@ -1,6 +1,6 @@
 # Stats
 
-[stats.js](https://github.com/mrdoob/stats.js/) is a JavaScript performance monitor, made by [mrdoop](https://github.com/mrdoob). stats.js provides a simple info box that will help you monitor your code performance.
+[stats.js](https://github.com/mrdoob/stats.js/) is a JavaScript performance monitor, made by [mrdoob](https://github.com/mrdoob). stats.js provides a simple info box that will help you monitor your code performance.
 
 - FPS Frames rendered in the last second. The higher the number the better.
 - MS Milliseconds needed to render a frame. The lower the number the better.

--- a/docs/guide/shapes/box.md
+++ b/docs/guide/shapes/box.md
@@ -19,7 +19,7 @@ Reference: [BoxGeometry](https://threejs.org/docs/?q=box#api/en/geometries/BoxGe
 
 ## Usage
 
-```html
+```vue
 <Box :args="[1, 1, 1]" color="orange" />
 
 // Box with a custom material transformations

--- a/docs/guide/shapes/circle.md
+++ b/docs/guide/shapes/circle.md
@@ -12,7 +12,7 @@ Reference: [CircleGeometry](https://threejs.org/docs/?q=circle#api/en/geometries
 
 ## Usage
 
-```html
+```vue
 <Circle :args="[1, 32]" color="lightsalmon" />
 
 // Circle with a custom material transformations

--- a/docs/guide/shapes/cone.md
+++ b/docs/guide/shapes/cone.md
@@ -20,7 +20,7 @@ Reference: [ConeGeometry](https://threejs.org/docs/?q=cone#api/en/geometries/Con
 
 ## Usage
 
-```html
+```vue
 <Cone :args="[1, 1, 8]" color="orange" />
 
 // Cone with a custom material transformations

--- a/docs/guide/shapes/dodecahedron.md
+++ b/docs/guide/shapes/dodecahedron.md
@@ -12,7 +12,7 @@ Reference: [DodecahedronGeometry](https://threejs.org/docs/?q=dode#api/en/geomet
 
 ## Usage
 
-```html
+```vue
 <Dodecahedron :args="[1, 0]" color="deeppink" />
 
 // Dodecahedron with a custom material transformations

--- a/docs/guide/shapes/icosahedron.md
+++ b/docs/guide/shapes/icosahedron.md
@@ -12,7 +12,7 @@ Reference: [IcosahedronGeometry](https://threejs.org/docs/?q=ico#api/en/geometri
 
 ## Usage
 
-```html
+```vue
 <Icosahedron :args="[1, 0]" color="red" />
 
 // Icosahedron with a custom material transformations

--- a/docs/guide/shapes/octahedron.md
+++ b/docs/guide/shapes/octahedron.md
@@ -12,7 +12,7 @@ Reference: [OctahedronGeometry](https://threejs.org/docs/?q=octa#api/en/geometri
 
 ## Usage
 
-```html
+```vue
 <Octahedron :args="[1, 0]" color="red" />
 
 // Octahedron with a custom material transformations

--- a/docs/guide/shapes/plane.md
+++ b/docs/guide/shapes/plane.md
@@ -16,7 +16,7 @@ A convenient default rotation is applied to the _x-axis_ of the plane (`-Math.PI
 
 ## Usage
 
-```html
+```vue
 <Plane :args="[1, 1]" color="teal" />
 
 // Plane with a custom material transformations

--- a/docs/guide/shapes/ring.md
+++ b/docs/guide/shapes/ring.md
@@ -19,7 +19,7 @@ Reference: [RingGeometry](https://threejs.org/docs/?q=ring#api/en/geometries/Rin
 
 ## Usage
 
-```html
+```vue
 <Ring :args="[0.5, 1, 32]" color="purple" />
 
 // Ring with a custom material transformations

--- a/docs/guide/shapes/sphere.md
+++ b/docs/guide/shapes/sphere.md
@@ -20,7 +20,7 @@ Reference: [SphereGeometry](https://threejs.org/docs/?q=sphere#api/en/geometries
 
 ## Usage
 
-```html
+```vue
 <Sphere :args="[1, 1, 1]" color="pink" />
 
 // Sphere with a custom material transformations

--- a/docs/guide/shapes/tetrahedron.md
+++ b/docs/guide/shapes/tetrahedron.md
@@ -12,7 +12,7 @@ Reference: [TetrahedronGeometry](https://threejs.org/docs/?q=tetr#api/en/geometr
 
 ## Usage
 
-```html
+```vue
 <Tetrahedron :args="[1, 0]" color="yellow" />
 
 // Tetrahedron with a custom material transformations

--- a/docs/guide/shapes/torus-knot.md
+++ b/docs/guide/shapes/torus-knot.md
@@ -19,7 +19,7 @@ Reference: [TorusKnotGeometry](https://threejs.org/docs/?q=torus#api/en/geometri
 
 ## Usage
 
-```html
+```vue
 <TorusKnot :args="[0.6, 0.2, 64, 8]" color="lime" />
 
 // TorusKnot with a custom material transformations

--- a/docs/guide/shapes/torus.md
+++ b/docs/guide/shapes/torus.md
@@ -18,7 +18,7 @@ Reference: [TorusGeometry](https://threejs.org/docs/?q=torus#api/en/geometries/T
 
 ## Usage
 
-```html
+```vue
 <Torus :args="[2, 0.4, 42, 100]" color="cyan" />
 
 // Torus with a custom material transformations

--- a/docs/guide/shapes/tube.md
+++ b/docs/guide/shapes/tube.md
@@ -4,6 +4,10 @@
 
 The `cientos` package provides a `<Tube />` component that serves as a short-cut for a `TubeGeometry` and a `MeshBasicMaterial` with a `Mesh` object.
 
+Reference: [TubeGeometry](https://threejs.org/docs/?q=tube#api/en/geometries/TubeGeometry)
+
+## Usage
+
 ```typescript
 <script>
 export default {
@@ -23,6 +27,18 @@ export default {
 </script>
 ```
 
+```vue
+// TubeGeometry needs a curve path to be construct
+<Tube :args="[tubePath, 20, 0.2, 8, false]" color="lightblue" />
+
+// Tube with a custom material transformations
+<Tube ref="tubeRef" :args="[tubePath, 20, 0.2, 8, false]" :position="[0, 4, 0]">
+  <TresMeshToonMaterial color="lightblue" />
+</Tube>
+```
+
+## Args
+
 ```typescript
 type CurveType = QuadraticBezierCurve3 | CubicBezierCurve3 | CatmullRomCurve3 | LineCurve3
 
@@ -33,18 +49,4 @@ args: [
   radialSegments: number,
   closed: boolean
 ]
-```
-
-Reference: [TubeGeometry](https://threejs.org/docs/?q=tube#api/en/geometries/TubeGeometry)
-
-## Usage
-
-```html
-// TubeGeometry needs a curve path to be construct
-<Tube :args="[tubePath, 20, 0.2, 8, false]" color="lightblue" />
-
-// Tube with a custom material transformations
-<Tube ref="tubeRef" :args="[tubePath, 20, 0.2, 8, false]" :position="[0, 4, 0]">
-  <TresMeshToonMaterial color="lightblue" />
-</Tube>
 ```

--- a/docs/guide/staging/backdrop.md
+++ b/docs/guide/staging/backdrop.md
@@ -8,7 +8,7 @@ The `cientos` package provides a `<Backdrop />` component. It's just a curved pl
 
 ## Usage
 
-```html
+```vue
 <Backdrop />
 
 // Backdrop with a custom material

--- a/docs/guide/staging/contact-shadows.md
+++ b/docs/guide/staging/contact-shadows.md
@@ -10,7 +10,7 @@ This component is used to create and manage contact shadows in a 3D scene. It is
 
 ## Usage
 
-```html {11}
+```vue{11}
 <template>
   <TresCanvas v-bind="gl">
     <TresPerspectiveCamera :position="[11, 11, 11]" />

--- a/docs/guide/staging/environment.md
+++ b/docs/guide/staging/environment.md
@@ -8,7 +8,7 @@ It uses the composable [useEnvironment](/guide/staging/use-environment) under th
 
 ## Usage
 
-```html
+```vue
 <Environment
   :files="[
     '/px.jpg',
@@ -23,7 +23,7 @@ It uses the composable [useEnvironment](/guide/staging/use-environment) under th
 
 You can also pass the `.hdr` file directly:
 
-```html
+```vue
 <Environment files="/sunset.hdr" />
 ```
 

--- a/docs/guide/staging/use-environment.md
+++ b/docs/guide/staging/use-environment.md
@@ -25,7 +25,7 @@ const texture = await useEnvironment({
 
 Then you can use the `texture` in your scene:
 
-```html{3}
+```vue{3}
 <TresMesh>
     <TresSphereGeometry />
     <TresMeshStandardMaterial :map="texture" />


### PR DESCRIPTION
I've updated some of the docs here. Mostly correcting minor typos and adjusting some phrasing. 

The PR also updates [outdated props names/defaults in the table here.](https://cientos.tresjs.org/guide/abstractions/mouse-parallax.html#props)

Let me know if this sort of fix is welcome. If so, I'll keep going. If not, then I'll stop. No problem either way.

----

I'm not an editor. My only relevant qualification is being an anglophone. 🤪