### PR TITLE
docs: import demos

### DIFF
--- a/docs/.vitepress/theme/components/CameraControlsDemo.vue
+++ b/docs/.vitepress/theme/components/CameraControlsDemo.vue
@@ -1,47 +1,26 @@
-<!-- eslint-disable no-console -->
 <script setup lang="ts">
-import { reactive, shallowRef } from 'vue'
+import { reactive } from 'vue'
 import { TresCanvas } from '@tresjs/core'
-import { CameraControls } from '@tresjs/cientos'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
-
-const gl = {
-  clearColor: '#82DBC5',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
+import { CameraControls, Box } from '@tresjs/cientos'
 
 const controlsState = reactive({
   minDistance: 0,
   maxDistance: 100,
 })
-
-const controlsRef = shallowRef()
-const boxMeshRef = shallowRef()
 </script>
 
 <template>
-  <TresCanvas v-bind="gl">
+  <TresCanvas clear-color="#82DBC5">
     <TresPerspectiveCamera :position="[5, 5, 5]" />
     <CameraControls
       v-bind="controlsState"
-      ref="controlsRef"
       make-default
     />
     <TresGridHelper :position="[0, -1, 0]" />
-    <TresMesh ref="boxMeshRef">
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshToonMaterial
-        color="orange"
-      />
-    </TresMesh>
-    <TresAmbientLight :intensity="1" />
-    <TresDirectionalLight
-      :intensity="1"
-      :position="[0, 2, 4]"
-    />
+    <Box :scale="2">
+      <TresMeshToonMaterial color="orange" />
+    </Box>
+    <TresAmbientLight />
+    <TresDirectionalLight :position="[0, 2, 4]" />
   </TresCanvas>
 </template>

--- a/docs/.vitepress/theme/components/GlassMaterialDemo.vue
+++ b/docs/.vitepress/theme/components/GlassMaterialDemo.vue
@@ -1,40 +1,22 @@
 <script setup lang="ts">
-import { ref, shallowRef, watch } from 'vue'
-import { TresCanvas, useTexture } from '@tresjs/core'
-import { OrbitControls, MeshGlassMaterial } from '@tresjs/cientos'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
-
-const gl = {
-  clearColor: '#82DBC5',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
+import { TresCanvas } from '@tresjs/core'
+import { MeshGlassMaterial, OrbitControls } from '@tresjs/cientos'
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas clear-color="#82DBC5">
     <TresPerspectiveCamera :position="[3, 3, 3]" />
-    <TresMesh :position-x="0">
+    <TresMesh>
       <TresTorusKnotGeometry :args="[1, 0.4, 256, 20]" />
       <MeshGlassMaterial />
     </TresMesh>
-    <TresMesh
-      :position="[0, 0, -1]"
-    >
+    <TresMesh :position="[0, 0, -1]">
       <TresPlaneGeometry :args="[5, 5]" />
       <TresMeshBasicMaterial :color="0xff1111" />
     </TresMesh>
     <TresGridHelper :args="[10, 10]" />
-    <TresAmbientLight :intensity="1" />
-    <TresDirectionalLight
-      :intensity="1"
-      :position="[2, 2, 2]"
-    />
+    <TresAmbientLight />
+    <TresDirectionalLight :position="[2, 2, 2]" />
     <OrbitControls />
   </TresCanvas>
 </template>

--- a/docs/.vitepress/theme/components/HtmlDemo.vue
+++ b/docs/.vitepress/theme/components/HtmlDemo.vue
@@ -1,22 +1,10 @@
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
-
-import { OrbitControls, Html } from '@tresjs/cientos'
-import { reactive } from 'vue'
-
-const gl = {
-  clearColor: '#82DBC5',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
+import { Html, OrbitControls } from '@tresjs/cientos'
 </script>
 
 <template>
-  <TresCanvas v-bind="gl">
+  <TresCanvas clear-color="#82DBC5">
     <TresPerspectiveCamera :position="[3, 3, 8]" />
     <OrbitControls />
     <TresMesh :position="[1, 1, 1]">
@@ -35,6 +23,6 @@ const gl = {
       </Html>
     </TresMesh>
     <TresGridHelper />
-    <TresAmbientLight :intensity="1" />
+    <TresAmbientLight />
   </TresCanvas>
 </template>

--- a/docs/.vitepress/theme/components/HtmlLaptopDemo.vue
+++ b/docs/.vitepress/theme/components/HtmlLaptopDemo.vue
@@ -1,29 +1,16 @@
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
+import { Html, useGLTF, ContactShadows, OrbitControls } from '@tresjs/cientos'
 
-import { OrbitControls, Html, useGLTF, Levioso, ContactShadows } from '@tresjs/cientos'
-
-const gl = {
-  clearColor: '#241a1a',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
-
-const { nodes } 
-  = await useGLTF('https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/macbook/model.gltf', 
-    { draco: true },
-  )
+const path = 'https://vazxmixjsiawhamofees.supabase.co/'
+  + 'storage/v1/object/public/models/macbook/model.gltf'
+const { nodes } = await useGLTF(path, { draco: true })
 </script>
 
 <template>
-  <TresCanvas v-bind="gl">
+  <TresCanvas clear-color="#241a1a">
     <TresPerspectiveCamera :position="[-5, 4, 3]" />
     <OrbitControls />
-
     <primitive :object="nodes.Macbook">
       <Html
         transform

--- a/docs/.vitepress/theme/components/HtmlOccludeDemo.vue
+++ b/docs/.vitepress/theme/components/HtmlOccludeDemo.vue
@@ -1,24 +1,13 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { TresCanvas } from '@tresjs/core'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
-
-import { OrbitControls, Html } from '@tresjs/cientos'
-import { reactive, ref } from 'vue'
-
-const gl = {
-  clearColor: '#82DBC5',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
+import { Html, OrbitControls } from '@tresjs/cientos'
 
 const sphereRef = ref(null)
 </script>
 
 <template>
-  <TresCanvas v-bind="gl">
+  <TresCanvas clear-color="#82DBC5">
     <TresPerspectiveCamera :position="[3, 3, 8]" />
     <OrbitControls />
     <TresMesh :position="[1, 1, 1]">
@@ -52,6 +41,6 @@ const sphereRef = ref(null)
       </Html>
     </TresMesh>
     <TresGridHelper />
-    <TresAmbientLight :intensity="1" />
+    <TresAmbientLight />
   </TresCanvas>
 </template>

--- a/docs/.vitepress/theme/components/MapControlsDemo.vue
+++ b/docs/.vitepress/theme/components/MapControlsDemo.vue
@@ -1,21 +1,10 @@
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
-
 import { MapControls, Sphere } from '@tresjs/cientos'
-
-const gl = {
-  clearColor: '#82DBC5',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
 </script>
 
 <template>
-  <TresCanvas v-bind="gl">
+  <TresCanvas clear-color="#82DBC5">
     <TresPerspectiveCamera :position="[3, 3, 3]" />
     <MapControls />
     <TresGridHelper />

--- a/docs/.vitepress/theme/components/MouseParallaxDemo.vue
+++ b/docs/.vitepress/theme/components/MouseParallaxDemo.vue
@@ -1,25 +1,13 @@
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
 import { MouseParallax, TorusKnot } from '@tresjs/cientos'
-
-const gl = {
-  clearColor: '#82DBC5',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
 </script>
 
 <template>
-  <TresCanvas v-bind="gl">
+  <TresCanvas clear-color="#82DBC5">
     <TresPerspectiveCamera
       :position="[0, 0, 7.5]"
       :fov="75"
-      :near="0.1"
-      :far="1000"
     />
     <TorusKnot>
       <TresMeshNormalMaterial />
@@ -28,6 +16,5 @@ const gl = {
       :factor="5"
       :ease="3"
     />
-    <TresAmbientLight :intensity="1" />
   </TresCanvas>
 </template>

--- a/docs/.vitepress/theme/components/OrbitControlsDemo.vue
+++ b/docs/.vitepress/theme/components/OrbitControlsDemo.vue
@@ -1,73 +1,17 @@
-<!-- eslint-disable no-console -->
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
-
-import { OrbitControls } from '@tresjs/cientos'
-import { reactive } from 'vue'
-
-const gl = {
-  clearColor: '#82DBC5',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
-
-const controlsState = reactive({
-  enableDamping: true,
-  dampingFactor: 0.05,
-  enableZoom: true,
-  autoRotate: false,
-  autoRotateSpeed: 2,
-  maxPolarAngle: Math.PI,
-  minPolarAngle: 0,
-  maxAzimuthAngle: Math.PI,
-  minAzimuthAngle: -Math.PI,
-  enablePan: true,
-  keyPanSpeed: 7,
-  maxDistance: 100,
-  minDistance: 0,
-  minZoom: 0,
-  maxZoom: 100,
-  zoomSpeed: 1,
-  enableRotate: true,
-  rotateSpeed: 1,
-})
-
-function onChange() {
-  /* console.log('change') */
-}
-
-function onStart() {
-  /*  console.log('start') */
-}
-
-function onEnd() {
-  /*   console.log('end') */
-}
+import { OrbitControls, Box } from '@tresjs/cientos'
 </script>
 
 <template>
-  <TresLeches />
-  <TresCanvas v-bind="gl">
+  <TresCanvas clear-color="#82DBC5">
     <TresPerspectiveCamera :position="[3, 3, 3]" />
-    <OrbitControls
-      v-bind="controlsState"
-      @change="onChange"
-      @start="onStart"
-      @end="onEnd"
-    />
-    <TresMesh>
-      <TresBoxGeometry :args="[2, 2, 2]" />
-      <TresMeshToonMaterial
-        color="orange"
-      />
-    </TresMesh>
-    <TresAmbientLight :intensity="1" />
+    <OrbitControls />
+    <Box :scale="2">
+      <TresMeshToonMaterial color="orange" />
+    </Box>
+    <TresAmbientLight />
     <TresDirectionalLight
-      :intensity="1"
       :position="[0, 2, 4]"
     />
     <TresGridHelper />

--- a/docs/.vitepress/theme/components/PrecipitationBeamDemo.vue
+++ b/docs/.vitepress/theme/components/PrecipitationBeamDemo.vue
@@ -1,25 +1,12 @@
 <script setup lang="ts">
-import { shallowRef, reactive } from 'vue'
 import { TresCanvas } from '@tresjs/core'
 import { Precipitation } from '@tresjs/cientos'
-import { SRGBColorSpace, NoToneMapping } from 'three'
-
-const gl = {
-  clearColor: '#333',
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
-
-const precipitationRef = shallowRef()
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas clear-color="#333">
     <TresPerspectiveCamera :position="[0, 2, 15]" />
     <Precipitation
-      ref="precipitationRef"
       :position="[0, 3, 7.5]"
       :randomness="0"
       :speed="0.5"

--- a/docs/.vitepress/theme/components/PrecipitationDemo.vue
+++ b/docs/.vitepress/theme/components/PrecipitationDemo.vue
@@ -1,26 +1,12 @@
 <script setup lang="ts">
-import { shallowRef } from 'vue'
 import { TresCanvas } from '@tresjs/core'
 import { Precipitation } from '@tresjs/cientos'
-import { SRGBColorSpace, NoToneMapping } from 'three'
-
-const gl = {
-  clearColor: '#333',
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
-
-const precipitationRef = shallowRef()
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas clear-color="#333">
     <TresPerspectiveCamera :position="[0, 2, 15]" />
-    <Precipitation
-      ref="precipitationRef"
-    />
+    <Precipitation />
     <TresGridHelper :args="[10, 10]" />
   </TresCanvas>
 </template>

--- a/docs/.vitepress/theme/components/PrecipitationRainDemo.vue
+++ b/docs/.vitepress/theme/components/PrecipitationRainDemo.vue
@@ -1,25 +1,12 @@
 <script setup lang="ts">
-import { shallowRef, reactive } from 'vue'
 import { TresCanvas } from '@tresjs/core'
 import { Precipitation } from '@tresjs/cientos'
-import { SRGBColorSpace, NoToneMapping } from 'three'
-
-const gl = {
-  clearColor: '#333',
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
-
-const precipitationRef = shallowRef()
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas clear-color="#333">
     <TresPerspectiveCamera :position="[0, 2, 15]" />
     <Precipitation
-      ref="precipitationRef"
       :randomness="0"
       :speed="1"
       :count="2500"

--- a/docs/.vitepress/theme/components/PrecipitationStormDemo.vue
+++ b/docs/.vitepress/theme/components/PrecipitationStormDemo.vue
@@ -1,25 +1,12 @@
 <script setup lang="ts">
-import { shallowRef, reactive } from 'vue'
 import { TresCanvas } from '@tresjs/core'
 import { Precipitation } from '@tresjs/cientos'
-import { SRGBColorSpace, NoToneMapping } from 'three'
-
-const gl = {
-  clearColor: '#333',
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
-
-const precipitationRef = shallowRef()
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas clear-color="#333">
     <TresPerspectiveCamera :position="[0, 2, 15]" />
     <Precipitation
-      ref="precipitationRef"
       :randomness="3"
       :speed="1"
       :count="2500"

--- a/docs/.vitepress/theme/components/ScrollControlsPagesDemo.vue
+++ b/docs/.vitepress/theme/components/ScrollControlsPagesDemo.vue
@@ -11,8 +11,8 @@ import { ScrollControls, Stars, Box } from '@tresjs/cientos'
     <TresPerspectiveCamera :position="[0, 2, 5]" />
     <Stars :radius="1" />
     <TresGridHelper :args="[10, 10]" />
-    <ScrollControls
-      :pages="20"
+    <ScrollControls 
+      :pages="20" 
       :distance="20"
       :smooth-scroll="0.05"
     />

--- a/docs/.vitepress/theme/components/StarsDemo.vue
+++ b/docs/.vitepress/theme/components/StarsDemo.vue
@@ -1,46 +1,24 @@
 <script setup lang="ts">
-import { shallowRef, reactive } from 'vue'
+import { shallowRef } from 'vue'
 import { TresCanvas, useRenderLoop } from '@tresjs/core'
-import { OrbitControls, Stars, MouseParallax } from '@tresjs/cientos'
-import { SRGBColorSpace, NoToneMapping } from 'three'
+import { Stars, OrbitControls } from '@tresjs/cientos'
 
-const gl = {
-  clearColor: '#333',
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
-const options = reactive({
-  size: 0.1,
-  sizeAttenuation: true,
-  count: 5000,
-  depth: 50,
-  radius: 100,
-})
-
-const star = shallowRef(null)
-
-const { onLoop } = useRenderLoop()
-
-onLoop(() => {
-  if (star.value) {
-    star.value.value.rotation.y += 0.001
-  }
+const yRotation = shallowRef(0)
+useRenderLoop().onLoop(({ delta }) => {
+  yRotation.value += 0.02 * delta
 })
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas clear-color="#333">
     <TresPerspectiveCamera :position="[0, 2, 5]" />
-    <MouseParallax :factor="0.5" />
     <Stars
-      ref="star"
-      :radius="options.radius"
-      :depth="options.depth"
-      :count="options.count"
-      :size="options.size"
-      :size-attenuation="options.sizeAttenuation"
+      :rotation="[0, yRotation, 0]"
+      :radius="50"
+      :depth="50"
+      :count="5000"
+      :size="0.3"
+      :size-attenuation="true"
     />
     <TresGridHelper :args="[4, 4]" />
     <OrbitControls />

--- a/docs/.vitepress/theme/components/UseFBXDemo.vue
+++ b/docs/.vitepress/theme/components/UseFBXDemo.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { FBXModel, OrbitControls } from '@tresjs/cientos'
+import { useFBX, OrbitControls } from '@tresjs/cientos'
+
+const path = 'https://raw.githubusercontent.com/'
+  + 'Tresjs/assets/main/models/fbx/low-poly-truck/Jeep_done.fbx'
+const model = await useFBX(path)
 </script>
 
 <template>
@@ -8,8 +12,8 @@ import { FBXModel, OrbitControls } from '@tresjs/cientos'
     <TresPerspectiveCamera :position="[11, 11, 11]" />
     <OrbitControls />
     <Suspense>
-      <FBXModel
-        path="https://raw.githubusercontent.com/Tresjs/assets/main/models/fbx/low-poly-truck/Jeep_done.fbx"
+      <primitive
+        :object="model"
         :scale="0.025"
       />
     </Suspense>
@@ -17,6 +21,6 @@ import { FBXModel, OrbitControls } from '@tresjs/cientos'
       :intensity="2"
       :position="[3, 3, 3]"
     />
-    <TresAmbientLight />
+    <TresAmbientLight :intensity="1" />
   </TresCanvas>
 </template>

--- a/docs/.vitepress/theme/components/UseGLTFDemo.vue
+++ b/docs/.vitepress/theme/components/UseGLTFDemo.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { GLTFModel, OrbitControls } from '@tresjs/cientos'
+import { useGLTF, OrbitControls } from '@tresjs/cientos'
+
+const path = 'https://raw.githubusercontent.com/'
++ 'Tresjs/assets/main/models/gltf/blender-cube.glb'
+const { scene } = await useGLTF(path)
 </script>
 
 <template>
@@ -8,7 +12,7 @@ import { GLTFModel, OrbitControls } from '@tresjs/cientos'
     <TresPerspectiveCamera :position="[3, 2, 5]" />
     <OrbitControls />
     <Suspense>
-      <GLTFModel path="https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/blender-cube.glb" />
+      <primitive :object="scene" />
     </Suspense>
     <TresDirectionalLight
       :intensity="2"

--- a/docs/.vitepress/theme/components/VideoTextureDemo.vue
+++ b/docs/.vitepress/theme/components/VideoTextureDemo.vue
@@ -1,28 +1,16 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useVideoTexture, OrbitControls, Sphere } from '@tresjs/cientos'
 import { TresCanvas } from '@tresjs/core'
-import { SRGBColorSpace, NoToneMapping } from 'three'
+import { useVideoTexture, OrbitControls, Sphere } from '@tresjs/cientos'
 
-const gl = {
-  clearColor: '#333',
-  alpha: true,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-  useLegacyLights: false,
-}
-
-const exampleVideo = 'https://raw.githubusercontent.com/Tresjs/assets/main/textures/video-textures/useVideoTexture.mp4'
-
+const exampleVideo = 'https://raw.githubusercontent.com/'
+  + 'Tresjs/assets/main/textures/video-textures/useVideoTexture.mp4'
 const texture = ref()
-
 texture.value = await useVideoTexture(exampleVideo, { loop: false })
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas clear-color="#333">
     <TresPerspectiveCamera
       :position="[0, 5, 9]"
       :look-at="[0, 1, 0]"
@@ -31,10 +19,7 @@ texture.value = await useVideoTexture(exampleVideo, { loop: false })
     <Sphere :position="[0, 2, 0]">
       <TresMeshBasicMaterial :map="texture" />
     </Sphere>
-    <TresGridHelper
-      :size="10"
-      :divisions="10"
-    />
-    <TresAmbientLight :intensity="1" />
+    <TresGridHelper />
+    <TresAmbientLight />
   </TresCanvas>
 </template>

--- a/docs/.vitepress/theme/components/WobbleMaterialDemo.vue
+++ b/docs/.vitepress/theme/components/WobbleMaterialDemo.vue
@@ -1,22 +1,10 @@
 <script setup lang="ts">
 import { TresCanvas } from '@tresjs/core'
-import { OrbitControls, MeshWobbleMaterial } from '@tresjs/cientos'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
-
-const gl = {
-  clearColor: '#82DBC5',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
+import { MeshWobbleMaterial, OrbitControls } from '@tresjs/cientos'
 </script>
 
 <template>
-  <TresCanvas
-    v-bind="gl"
-  >
+  <TresCanvas clear-color="#82DBC5">
     <TresPerspectiveCamera :position="[3, 3, 3]" />
     <TresMesh>
       <TresTorusGeometry />
@@ -27,10 +15,7 @@ const gl = {
       />
     </TresMesh>
     <TresAmbientLight :intensity="1" />
-    <TresDirectionalLight
-      :intensity="1"
-      :position="[2, 2, 2]"
-    />
+    <TresDirectionalLight :position="[2, 2, 2]" />
     <OrbitControls />
   </TresCanvas>
 </template>

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -8,11 +8,9 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     BackdropDemo: typeof import('./.vitepress/theme/components/BackdropDemo.vue')['default']
-    BackdropSimpleDemo: typeof import('./.vitepress/theme/components/BackdropSimpleDemo.vue')['default']
     CameraControlsDemo: typeof import('./.vitepress/theme/components/CameraControlsDemo.vue')['default']
     CatmullRomCurve3Demo: typeof import('./.vitepress/theme/components/CatmullRomCurve3Demo.vue')['default']
     ContactShadowDemo: typeof import('./.vitepress/theme/components/ContactShadowDemo.vue')['default']
-    copy: typeof import('./.vitepress/theme/components/FBXModelDemo copy.vue')['default']
     DocsDemo: typeof import('./.vitepress/theme/components/DocsDemo.vue')['default']
     FBXModelDemo: typeof import('./.vitepress/theme/components/FBXModelDemo.vue')['default']
     Feather: typeof import('./.vitepress/theme/components/Feather.vue')['default']
@@ -45,8 +43,6 @@ declare module 'vue' {
     SVGDemo: typeof import('./.vitepress/theme/components/SVGDemo.vue')['default']
     Text3Demo: typeof import('./.vitepress/theme/components/Text3Demo.vue')['default']
     TransformControlsDemo: typeof import('./.vitepress/theme/components/TransformControlsDemo.vue')['default']
-    UseFBXDemo: typeof import('./.vitepress/theme/components/UseFBXDemo.vue')['default']
-    UseGLTFDemo: typeof import('./.vitepress/theme/components/UseGLTFDemo.vue')['default']
     VideoTextureDemo: typeof import('./.vitepress/theme/components/VideoTextureDemo.vue')['default']
     WobbleMaterialDemo: typeof import('./.vitepress/theme/components/WobbleMaterialDemo.vue')['default']
   }

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -8,9 +8,11 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     BackdropDemo: typeof import('./.vitepress/theme/components/BackdropDemo.vue')['default']
+    BackdropSimpleDemo: typeof import('./.vitepress/theme/components/BackdropSimpleDemo.vue')['default']
     CameraControlsDemo: typeof import('./.vitepress/theme/components/CameraControlsDemo.vue')['default']
     CatmullRomCurve3Demo: typeof import('./.vitepress/theme/components/CatmullRomCurve3Demo.vue')['default']
     ContactShadowDemo: typeof import('./.vitepress/theme/components/ContactShadowDemo.vue')['default']
+    copy: typeof import('./.vitepress/theme/components/FBXModelDemo copy.vue')['default']
     DocsDemo: typeof import('./.vitepress/theme/components/DocsDemo.vue')['default']
     FBXModelDemo: typeof import('./.vitepress/theme/components/FBXModelDemo.vue')['default']
     Feather: typeof import('./.vitepress/theme/components/Feather.vue')['default']
@@ -43,6 +45,8 @@ declare module 'vue' {
     SVGDemo: typeof import('./.vitepress/theme/components/SVGDemo.vue')['default']
     Text3Demo: typeof import('./.vitepress/theme/components/Text3Demo.vue')['default']
     TransformControlsDemo: typeof import('./.vitepress/theme/components/TransformControlsDemo.vue')['default']
+    UseFBXDemo: typeof import('./.vitepress/theme/components/UseFBXDemo.vue')['default']
+    UseGLTFDemo: typeof import('./.vitepress/theme/components/UseGLTFDemo.vue')['default']
     VideoTextureDemo: typeof import('./.vitepress/theme/components/VideoTextureDemo.vue')['default']
     WobbleMaterialDemo: typeof import('./.vitepress/theme/components/WobbleMaterialDemo.vue')['default']
   }

--- a/docs/guide/abstractions/mouse-parallax.md
+++ b/docs/guide/abstractions/mouse-parallax.md
@@ -12,19 +12,7 @@ You only need to import it and add it to your template as `<MouseParallax />`. A
 
 `factor` is a number to increase the movement range of the camera. `ease` is a number that smoothes the movement. You can also disable the effect with the `disabled` prop.
 
-```vue
-<template>
-  <TresCanvas>
-    <MouseParallax />
-    <Text3D
-      text="TresJS"
-      font="/fonts/FiraCodeRegular.json"
-    >
-      <TresMeshNormalMaterial />
-    </Text3D>
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/MouseParallaxDemo.vue{3,15-18}
 
 ## Props
 

--- a/docs/guide/controls/camera-controls.md
+++ b/docs/guide/controls/camera-controls.md
@@ -16,14 +16,7 @@ It just works. 💯
 
 ## Usage
 
-```vue{4}
-<template>
-  <TresCanvas shadows alpha>
-    <TresPerspectiveCamera :args="[45, 1, 0.1, 1000]" />
-    <CameraControls />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/CameraControlsDemo.vue{4,15-18}
 
 ::: warning
 Is really important that the Perspective camera is set first in the canvas. Otherwise might break.

--- a/docs/guide/controls/map-controls.md
+++ b/docs/guide/controls/map-controls.md
@@ -16,15 +16,7 @@ It just works. 💯
 
 ## Usage
 
-```vue{4}
-<template>
-  <TresCanvas shadows alpha>
-    <TresPerspectiveCamera :position="[0, 0, 3]" />
-    <MapControls />
-    <TresGridHelper :args="[10, 10]" />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/MapControlsDemo.vue{3,9}
 
 ::: warning
 Is really important that the Perspective camera is set first in the canvas. Otherwise might break.

--- a/docs/guide/controls/orbit-controls.md
+++ b/docs/guide/controls/orbit-controls.md
@@ -17,14 +17,7 @@ It just works. 💯
 
 ## Usage
 
-```vue{4}
-<template>
-  <TresCanvas shadows alpha>
-    <TresPerspectiveCamera :args="[45, 1, 0.1, 1000]" />
-    <OrbitControls />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/OrbitControlsDemo.vue{3,9}
 
 ::: warning
 Is really important that the Perspective camera is set first in the canvas. Otherwise might break.

--- a/docs/guide/controls/scroll-controls.md
+++ b/docs/guide/controls/scroll-controls.md
@@ -12,21 +12,7 @@ The `cientos` package create this controls from scratch for you, and comes with 
 
 To start using it, you just need to import it and play with it.
 
-```vue{10}
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { ScrollControls, Stars, Box } from '@tresjs/cientos'
-</script>
-<template>
-  <TresCanvas clear-color="#333" >
-    <TresPerspectiveCamera :position="[0, 2, 5]" />
-    <Stars :radius="1" />
-    <TresGridHelper :args="[10, 10]" />
-    <ScrollControls />
-    <Box :scale="0.5" :color="0xff00ff" :position="[-1, 1, 0]" />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/ScrollControlsDemo.vue{3,14}
 
 ::: warning
 Is really important that the Perspective camera is set first in the canvas. Otherwise might break.
@@ -38,21 +24,7 @@ You can use the `horizontal` prop, to makes the scroll horizontal way.
   <ScrollControlsHorizontalDemo />
 </DocsDemo>
 
-```vue{4}
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { ScrollControls, Stars, Box } from '@tresjs/cientos'
-</script>
-<template>
-  <TresCanvas clear-color="#333" >
-    <TresPerspectiveCamera :position="[0, 2, 5]" />
-    <Stars :radius="1" />
-    <TresGridHelper :args="[10, 10]" />
-    <ScrollControls horizontal />
-    <Box :scale="0.5" :color="0xff00ff" :position="[-1, 1, 0]" />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/ScrollControlsHorizontalDemo.vue{3,14}
 
 With the `pages` prop you can control the length of the scroll, and with the `distance` you can control how much movement is apply to the objects ( you can for example use it with 0 value and use the progress element)
 
@@ -61,23 +33,7 @@ In addition a nice effect could be achieve by using the `smoothScroll` prop like
   <ScrollControlsPagesDemo />
 </DocsDemo>
 
-```vue{8-11}
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { ScrollControls, Stars, Box } from '@tresjs/cientos'
-</script>
-<template>
-  <TresCanvas>
-    <TresPerspectiveCamera :position="[0, 0, 3]" />
-    <ScrollControls
-    :pages="20" // the scroll length will be really long
-    :distance="20" // the camera will move more units
-    :smoothScroll="0.05" // creates a smooth scroll effect
-    />
-    <TresGridHelper :args="[10, 10]" />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/ScrollControlsPagesDemo.vue{14-18}
 
 By default `ScrollControls` creates a scroll around the canvas and takes the camera as a default for animate, also it comes with a reactive `progress` param that returns a normalized value from 0 (start point) to 1 (end point) you just need to attach it to a v-model.
 
@@ -85,37 +41,7 @@ By default `ScrollControls` creates a scroll around the canvas and takes the cam
   <ScrollControlsProgressDemo />
 </DocsDemo>
 
-```vue{7,24-25}
-<script setup lang="ts">
-import { ref } from 'vue'
-import { TresCanvas, useRenderLoop } from '@tresjs/core'
-import { ScrollControls, Stars, Box } from '@tresjs/cientos'
-
-const boxRef = ref()
-const progress = ref(0) // it wil receive a numeric value
-
-const { onLoop } = useRenderLoop()
-onLoop(() => {
-  if (boxRef.value) {
-    boxRef.value.value.rotation.x = progress.value * 10
-    boxRef.value.value.rotation.y = progress.value * 2
-    boxRef.value.value.position.x = progress.value * 4
-  }
-})
-</script>
-<template>
-  <TresCanvas clear-color="#333" >
-    <TresPerspectiveCamera :position="[0, 2, 5]" />
-    <Stars :radius="1" />
-    <TresGridHelper :args="[10, 10]" />
-    <ScrollControls
-      v-model="progress"
-      :distance="2"
-    />
-    <Box ref="boxRef" :scale="0.5" :color="0xff00ff" :position="[-1, 1, 0]" />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/ScrollControlsProgressDemo.vue{7,27-30}
 
 If you don't want to use the default camera movement you can set the distance to 0 a just rely on progress to animate (the progress is not affected by the `smoothScroll` )
 
@@ -142,41 +68,7 @@ The elements that you pass as a slot will be affected by the scroll effect, and 
   <ScrollControlsSlotsDemo />
 </DocsDemo>
 
-```vue{24-30}
-<script setup lang="ts">
-import { ref } from 'vue'
-import { TresCanvas, useRenderLoop } from '@tresjs/core'
-import { ScrollControls, Stars, Sphere, Box } from '@tresjs/cientos'
-
-const scRef = ref()
-const boxRef = ref()
-const progress = ref(0)
-
-const { onLoop } = useRenderLoop()
-onLoop(() => {
-  if (boxRef.value) {
-    boxRef.value.value.rotation.x = progress.value * 10
-    boxRef.value.value.rotation.y = progress.value * 2
-  }
-})
-</script>
-<template>
-  <TresCanvas clear-color="#333" >
-    <TresPerspectiveCamera :position="[0, 2, 5]" />
-    <Stars :radius="1" />
-    <TresGridHelper :args="[10, 10]" />
-    <Sphere :scale="0.1" :position="[1, 2, 0]" />
-    <ScrollControls
-      v-model="progress"
-      :distance="20"
-      :smooth-scroll="0.1"
-    >
-      <Box ref="boxRef" :scale="0.5" :color="0xff00ff" :position="[-1, 1, 0]" />
-    </ScrollControls>
-  </TresCanvas>
-</template>
-
-```
+<<< @/.vitepress/theme/components/ScrollControlsSlotsDemo.vue{31-43}
 
 ## Props
 

--- a/docs/guide/loaders/fbx-model.md
+++ b/docs/guide/loaders/fbx-model.md
@@ -8,21 +8,7 @@ The `FBXModel` component is a wrapper around [`useFBX`](./use-fbx.md) composable
 
 ## Usage
 
-```vue{2,9}
-<script setup lang="ts">
-import { OrbitControls, FBXModel } from '@tresjs/cientos'
-</script>
-<template>
-    <TresCanvas clear-color="#82DBC5" shadows alpha>
-      <TresPerspectiveCamera :position="[11, 11, 11]" />
-      <OrbitControls />
-      <Suspense>
-        <FBXModel path="/models/Jeep.fbx" />
-      </Suspense>
-      <TresDirectionalLight :position="[-4, 8, 4]" :intensity="1.5" cast-shadow />
-    </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/FBXModelDemo.vue{3,10-15}
 
 ## Props
 

--- a/docs/guide/loaders/gltf-model.md
+++ b/docs/guide/loaders/gltf-model.md
@@ -8,21 +8,7 @@ The `GLTFModel` component is a wrapper around [`useGLTF`](./use-gltf.md) composa
 
 ## Usage
 
-```vue{2,9}
-<script setup lang="ts">
-import { OrbitControls, GLTFModel } from '@tresjs/cientos'
-</script>
-<template>
-    <TresCanvas clear-color="#82DBC5" shadows alpha>
-      <TresPerspectiveCamera :position="[11, 11, 11]" />
-      <OrbitControls />
-      <Suspense>
-        <GLTFModel path="/models/AkuAku.gltf" draco ref="modelRef" />
-      </Suspense>
-      <TresDirectionalLight :position="[-4, 8, 4]" :intensity="1.5" cast-shadow />
-    </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/GLTFModelDemo.vue{3,10-12}
 
 ## Model reference
 

--- a/docs/guide/loaders/use-fbx.md
+++ b/docs/guide/loaders/use-fbx.md
@@ -1,25 +1,11 @@
 # useFBX
 
 <DocsDemo>
-  <FBXModelDemo />
+  <UseFBXDemo />
 </DocsDemo>
 
 A composable that allows you to easily load glTF models into your **TresJS** scene.
 
 ## Usage
 
-```ts
-import { useFBX } from '@tresjs/cientos'
-
-const model = await useFBX('/models/Jeep.fbx')
-```
-
-Then is as straightforward as adding the scene to your scene:
-
-```vue{3}
-<TresCanvas shadows alpha>
-  <Suspense>
-    <primitive :object="scene" />
-  </Suspense>
-</TresCanvas>
-```
+<<< @/.vitepress/theme/components/UseFBXDemo.vue{3,7,14-19}

--- a/docs/guide/loaders/use-gltf.md
+++ b/docs/guide/loaders/use-gltf.md
@@ -1,28 +1,14 @@
 # useGLTF
 
 <DocsDemo>
-  <GLTFModelDemo />
+  <UseGLTFDemo />
 </DocsDemo>
 
 A composable that allows you to easily load glTF models into your **TresJS** scene.
 
 ## Usage
 
-```ts
-import { useGLTF } from '@tresjs/cientos'
-
-const { scene } = await useGLTF('/models/AkuAku.gltf')
-```
-
-Then is as straightforward as adding the scene to your scene:
-
-```vue{3}
-<TresCanvas shadows alpha>
-  <Suspense>
-    <primitive :object="scene" />
-  </Suspense>
-</TresCanvas>
-```
+<<< @/.vitepress/theme/components/UseGLTFDemo.vue{3,7,14-16}
 
 An advantage of using `useGLTF`is that you can pass a `draco` prop to enable [Draco compression](https://threejs.org/docs/index.html?q=drac#examples/en/loaders/DRACOLoader) for the model. This will reduce the size of the model and improve performance.
 

--- a/docs/guide/loaders/use-video-texture.md
+++ b/docs/guide/loaders/use-video-texture.md
@@ -10,23 +10,7 @@ This composable is based on the Drei [useVideoTexture](https://github.com/pmndrs
 
 ## Usage
 
-```ts
-import { useVideoTexture } from '@tresjs/cientos'
-import exampleVideo from '/myVideoPath'
-
-const texture = ref()
-texture.value = await useVideoTexture(exampleVideo, { loop: false })
-```
-
-Then you can use the texture in your material, for example:
-
-```vue{3}
-...
-    <Sphere :position="[0, 2, 0]">
-      <TresMeshBasicMaterial :map="texture" />
-    </Sphere>
-...
-```
+<<< @/.vitepress/theme/components/VideoTextureDemo.vue{4,8-9,20}
 
 ## Props
 

--- a/docs/guide/materials/glass-material.md
+++ b/docs/guide/materials/glass-material.md
@@ -10,12 +10,7 @@ The `cientos` package provides a new`<MeshGlassMaterial />` component that makes
 
 ### You can use it like you normally do with TresJs
 
-```vue{3}
-<TresMesh>
-  <TresTorusGeometry />
-  <MeshGlassMaterial />
-</TresMesh>
-```
+<<< @/.vitepress/theme/components/GlassMaterialDemo.vue{3,9-12}
 
 ### You can also replace the material of an existing mesh like this:
 

--- a/docs/guide/materials/wobble-material.md
+++ b/docs/guide/materials/wobble-material.md
@@ -11,9 +11,4 @@ The `cientos` package provides a `<MeshWobbleMaterial />` component that makes a
 
 ## Usage
 
-```vue
-<TresMesh>
-  <TresTorusGeometry />
-  <MeshWobbleMaterial color="orange" speed="10" factor="5" />
-</TresMesh>
-```
+<<< @/.vitepress/theme/components/WobbleMaterialDemo.vue{3,11-15}

--- a/docs/guide/misc/html-component.md
+++ b/docs/guide/misc/html-component.md
@@ -8,23 +8,7 @@ This component allows you to project HTML content to any object in your scene. T
 
 ## Usage
 
-```html
-<TresMesh :position="[1, 1, 1]">
-  <TresBoxGeometry />
-  <TresMeshNormalMaterial />
-  <Html
-    center
-    transform
-    :distance-factor="4"
-    :position="[0.5, 0, 0.65]"
-    :scale="[0.75, 0.75, 0.75]"
-  >
-    <h1 class="bg-white text-xs p-1 rounded">
-      I'm a Box 📦
-    </h1>
-  </Html>
-</TresMesh>
-```
+<<< @/.vitepress/theme/components/HtmlDemo.vue{3,13-23}
 
 ## Occlusion
 
@@ -42,49 +26,7 @@ You can also choose which objects should occlude the HTML content by passing an 
   <HtmlOccludeDemo />
 </DocsDemo>
 
-```html
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { OrbitControls, Html } from '@tresjs/cientos'
-
-const sphereRef = ref(null)
-</script>
-
-<template>
-  <TresCanvas v-bind="gl">
-    <TresMesh :position="[1, 1, 1]">
-      <TresBoxGeometry />
-      <TresMeshNormalMaterial />
-      <Html
-        center
-        transform
-        :occlude="[sphereRef]"
-        :distance-factor="4"
-      >
-        <h1 class="bg-white text-xs p-1 rounded">
-          Box
-        </h1>
-      </Html>
-    </TresMesh>
-    <TresMesh
-      ref="sphereRef"
-      :position="[3, 1, 1]"
-    >
-      <TresSphereGeometry />
-      <TresMeshNormalMaterial />
-      <Html
-        center
-        transform
-        :distance-factor="4"
-      >
-        <h1 class="bg-white text-xs p-1 rounded">
-          Sphere
-        </h1>
-      </Html>
-    </TresMesh>
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/HtmlOccludeDemo.vue{2,6,19,28}
 
 ## Using `iframes`
 
@@ -94,69 +36,7 @@ You can achieve pretty cool results with the `Html` component by using iframes. 
   <HtmlLaptopDemo />
 </DocsDemo>
 
-```html
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
-
-import { OrbitControls, Html, useGLTF, Levioso, ContactShadows } from '@tresjs/cientos'
-
-const gl = {
-  clearColor: '#241a1a',
-  shadows: true,
-  alpha: false,
-  shadowMapType: BasicShadowMap,
-  outputColorSpace: SRGBColorSpace,
-  toneMapping: NoToneMapping,
-}
-
-const { nodes } 
-  = await useGLTF('https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/macbook/model.gltf', 
-    { draco: true },
-  )
-</script>
-
-<template>
-  <TresCanvas v-bind="gl">
-    <TresPerspectiveCamera :position="[-5, 4, 3]" />
-    <OrbitControls />
-    <Levioso>
-      <primitive :object="nodes.Macbook">
-        <Html
-          transform
-          wrapper-class="webpage"
-          :distance-factor="11"
-          :position="[0, 10.5, -13.4]"
-          occlude
-          :rotation-x="-0.256"
-        >
-          <iframe
-            class="rounded-lg w-[1024px] h-[670px]"
-            src="https://tresjs.org"
-            frameborder="0"
-          />
-        </Html>
-      </primitive>
-    </Levioso>
-    <ContactShadows
-      :blur="3.5"
-      :resolution="512"
-      :opacity="1"
-    />
-    <TresAmbientLight :intensity="1" />
-    <TresDirectionalLight
-      :intensity="2"
-      :position="[2, 3, 0]"
-      :cast-shadow="true"
-      :shadow-camera-far="50"
-      :shadow-camera-left="-10"
-      :shadow-camera-right="10"
-      :shadow-camera-top="10"
-      :shadow-camera-bottom="-10"
-    />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/HtmlLaptopDemo.vue{23-27}
 
 ## Props
 

--- a/docs/guide/staging/precipitation.md
+++ b/docs/guide/staging/precipitation.md
@@ -10,19 +10,9 @@
 
 You can use `<Precipitation />` component without passing any props, this will achieve a snowy effect, like the before example.
 
-```vue{8}
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { Precipitation } from '@tresjs/cientos'
-</script>
-<template>
-  <TresCanvas>
-    <TresPerspectiveCamera :position="[0, 2, 15]" />
-    <Precipitation />
-    <TresGridHelper :args="[10, 10]" />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/PrecipitationDemo.vue{3,9}
+
+### Rain
 
 By setting the randomness to 0, increase the speed  and reduce the count. You can easily achieve a more rainy effect.
 
@@ -30,74 +20,28 @@ By setting the randomness to 0, increase the speed  and reduce the count. You ca
   <PrecipitationRainDemo />
 </DocsDemo>
 
+<<< @/.vitepress/theme/components/PrecipitationRainDemo.vue{3,9-13}
 
-```vue{9,10,11}
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { Precipitation } from '@tresjs/cientos'
-</script>
-<template>
-  <TresCanvas>
-    <TresPerspectiveCamera :position="[0, 2, 15]" />
-    <Precipitation
-      :speed="1"
-      :randomness="0"
-      :count="2500"
-    />
-    <TresGridHelper :args="[10, 10]" />
-  </TresCanvas>
-</template>
-```
+### Storm
+
 A storm effect? Easy just increase the randomness.
 
 <DocsDemo>
   <PrecipitationStormDemo />
 </DocsDemo>
 
-```vue{9,10,11}
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { Precipitation } from '@tresjs/cientos'
-</script>
-<template>
-  <TresCanvas>
-    <TresPerspectiveCamera :position="[0, 2, 15]" />
-    <Precipitation
-      :speed="1"
-      :randomness="3"
-      :count="2500"
-    />
-    <TresGridHelper :args="[10, 10]" />
-  </TresCanvas>
-</template>
-```
+<<< @/.vitepress/theme/components/PrecipitationStormDemo.vue{3,9-13}
 
-What about an infinite beam?.
+### Beam
+
+What about an infinite beam? Just set the area, to the axis that you need constrain.
 
 <DocsDemo>
   <PrecipitationBeamDemo />
 </DocsDemo>
 
-Just set the area, to the axis that you need constrain.
+<<< @/.vitepress/theme/components/PrecipitationBeamDemo.vue{3,9-15}
 
-```vue{9,10,11,12}
-<script setup lang="ts">
-import { TresCanvas } from '@tresjs/core'
-import { Precipitation } from '@tresjs/cientos'
-</script>
-<template>
-  <TresCanvas>
-    <TresPerspectiveCamera :position="[0, 2, 15]" />
-    <Precipitation
-      :randomness="0"
-      :speed="0.5"
-      :count="2000"
-      :area="[1, 10, 1]"
-    />
-    <TresGridHelper :args="[10, 10]" />
-  </TresCanvas>
-</template>
-```
 You can create much more! ☔
 
 ::: warning

--- a/docs/guide/staging/stars.md
+++ b/docs/guide/staging/stars.md
@@ -8,7 +8,7 @@
 
 ## Usage
 
-You can use `<Stars />` component without passing any props, but still if you want you can tweak the props to find the best setup for you
+You can use `<Stars />` component without passing any props, 
 
 ```vue
 <template>
@@ -19,6 +19,10 @@ You can use `<Stars />` component without passing any props, but still if you wa
   </TresCanvas>
 </template>
 ```
+
+But still if you want you can tweak the props to find the best setup for you.
+
+<<< @/.vitepress/theme/components/StarsDemo.vue{4,15-22}
 
 Notice that you can pass a texture as an alphaMap to personalize the star shape
 


### PR DESCRIPTION
This closes #242 .

* Since the demo source wasn't written to be viewed directly, there was often more code in them then absolutely necessary. I tried to take as much out as I could while maintaining the look of the demo – e.g., removing `<TresCanvas v-bind="gl" />` and `gl` object and replacing it with `<TresCanvas clear-color="#333">`, or removing refs. I don't think that's noticeable for the most part, but let me know if I went too far.
* In a few places, I couldn't shorten the demos and maintain the visual effects or functionality, so I left the copy/pasted source code snippets. `BackdropDemo.vue` is one instance. (Note that it *is* possible to include a [VSCode-style region](https://vitepress.dev/guide/markdown#import-code-snippets), but I didn't want to complicate things. Only whole files are imported at the moment.)
* Ideally, code highlighting would be specified in the`.vue` demo files, not in the `.md` files. That's possible with the current system. But when the `.vue` files are parsed for rendering, they throw an error if used *within* a Vue component, e.g.:

```
<Box
   color="orange" // [!code hl]
   :size="1"
/>
```

Highlighting a component over multiple lines is a really common case for us. Since that breaks the demos, to keep things consistent, I left all highlighting in the `.md` files. That looks like this:

```
<<< @/.vitepress/theme/components/HtmlOccludeDemo.vue{2,6,19,28}
```

Above the lines 2, 6, 19, and 28 are highlighted.