### PR TITLE
fix(OrbitControls): expose ref

### DIFF
--- a/src/core/controls/OrbitControls.vue
+++ b/src/core/controls/OrbitControls.vue
@@ -316,7 +316,7 @@ onUnmounted(() => {
   }
 })
 
-defineExpose({value:controlsRef})
+defineExpose({ value: controlsRef })
 </script>
 
 <template>

--- a/src/core/controls/OrbitControls.vue
+++ b/src/core/controls/OrbitControls.vue
@@ -315,6 +315,8 @@ onUnmounted(() => {
     controlsRef.value.dispose()
   }
 })
+
+defineExpose({value:controlsRef})
 </script>
 
 <template>


### PR DESCRIPTION
Closes #249

## Problem

In Cientos' `<OrbitControls />`, the camera and update functions aren't exposed.

## Solution

Expose a ref to the component using Vue's `defineExpose`. This is the approach taken by other Cientos' components, e.g., Levioso:

https://github.com/Tresjs/cientos/blob/106914ecbad38c65abb534f1f083e235ca370dc0/src/core/abstractions/Levioso.vue#L23

With this PR, the camera is accessible via `[refName].value.value.object`. Update() is available via `[refName].value.value.update`.