### PR TITLE
chore: ignore .DS_Store everywhere, components.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 .idea
-.DS_Store
+**/.DS_Store
 *.suo
 *.ntvs*
 *.njsproj
@@ -26,3 +26,5 @@ stats.html
 docs/.vitepress/dist/
 docs/.vitepress/cache/
 docs/.vitepress/.temp/
+docs/components.d.ts
+docs/


### PR DESCRIPTION
## Problem

* .DS_Store files outside of the root directory aren't being ignored
* /docs/components.d.ts is autogenerated and gets created/updated whenever a docs component is created/updated – leading to merge conflicts

## Solution

Change .gitignore

* Modify `.DS_Store` => `**/.DS_Store` [(to also ignore in all subdirectories)](https://stackoverflow.com/questions/18393498/gitignore-all-the-ds-store-files-in-every-folder-and-subfolder)
* Add `docs/components.d.ts` to .gitignore