### PR TITLE
revert(docs): remove docs/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ docs/.vitepress/dist/
 docs/.vitepress/cache/
 docs/.vitepress/.temp/
 docs/components.d.ts
-docs/


### PR DESCRIPTION
## Problem

All of ./docs/ was included in .gitignore by mistake (by me). 

## Solution

Removing.