### PR TITLE
fix: Correct return type for useGLTF composable

### DIFF
--- a/src/core/loaders/useGLTF/index.ts
+++ b/src/core/loaders/useGLTF/index.ts
@@ -61,12 +61,16 @@ function setExtensions(options: GLTFLoaderOptions, extendLoader?: (loader: GLTFL
  * @param {(loader: GLTFLoader) => void} [extendLoader]
  * @return {*}  {Promise<GLTFResult>}
  */
-export async function useGLTF(
-  path: string | string[],
+export async function useGLTF<T extends string | string[]>(
+  path: T,
   options: GLTFLoaderOptions = {
     draco: false,
   },
-  extendLoader?: (loader: GLTFLoader) => void,
-): Promise<GLTFResult> {
-  return (await useLoader(GLTFLoader, path, setExtensions(options, extendLoader))) as unknown as GLTFResult
+  extendLoader?: (loader: GLTFLoader) => void
+): Promise<T extends string[] ? GLTFResult[] : GLTFResult> {
+  return await useLoader(
+    GLTFLoader,
+    path,
+    setExtensions(options, extendLoader)
+  );
 }


### PR DESCRIPTION
Added conditional return type to infer the actual return type when passing strings or arrays as currently it always return GTLFResult and that is not always correct.
![image](https://github.com/Tresjs/cientos/assets/134087665/7c9adaa5-21e1-4be6-9d8c-bd5602cd388e)
With proposed changes
![image](https://github.com/Tresjs/cientos/assets/134087665/1a3caaf3-99e4-4f09-bfaa-2d0d767033cf)
![image](https://github.com/Tresjs/cientos/assets/134087665/d417c5d3-cdca-468e-9440-32243e638696)

The type is correctly set and allows me to do this
![image](https://github.com/Tresjs/cientos/assets/134087665/131d081c-107f-4a7a-ad6b-c57af478602d)
