### PR TITLE
feat(AnimatedSprite): add AnimatedSprite

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
           { text: 'useFBO', link: '/guide/abstractions/use-fbo' },
           { text: 'useSurfaceSampler', link: '/guide/abstractions/use-surface-sampler' },
           { text: 'Sampler', link: '/guide/abstractions/sampler' },
+          { text: 'AnimatedSprite', link: '/guide/abstractions/animated-sprite' },
         ],
       },
       {

--- a/docs/.vitepress/theme/components/AnimatedSpriteAnchorDemo.vue
+++ b/docs/.vitepress/theme/components/AnimatedSpriteAnchorDemo.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+import { OrbitControls, Line2, AnimatedSprite } from '@tresjs/cientos'
+import { TresLeches, useControls } from '@tresjs/leches'
+import '@tresjs/leches/styles'
+import { TexturePackerFrameDataArray } from '../../../../src/core/abstractions/AnimatedSprite/Atlas'
+
+const { anchorX, anchorY, fps } = useControls({
+  anchorX: { value: 0.5, min: 0, max: 1, step: 0.1 },
+  anchorY: { value: 0.5, min: 0, max: 1, step: 0.1 },
+  fps: {value:5, min:0, max:30, step:1}
+})
+
+const anchorDemoAtlas: TexturePackerFrameDataArray = { frames: [] }
+const anchorDemoImgData = (() => {
+  const NUM_ROWS_COLS = 64
+  const rects: { x: number, y: number, w: number, h: number }[] = []
+  let h = 0
+  for (let r = 0; r < NUM_ROWS_COLS; r += h) {
+    let w = 0
+    h++
+    if (r + h >= NUM_ROWS_COLS) {
+      continue
+    }
+    for (let c = 0; c < NUM_ROWS_COLS; c += w) {
+      w++
+      if (c + w >= NUM_ROWS_COLS) {
+        continue
+      }
+      rects.push({ x: c, y: r, w, h })
+    }
+  }
+
+  const canvas = document.createElement('canvas')
+  const IMG_SIZE = 2048
+  const COL_SIZE = IMG_SIZE / NUM_ROWS_COLS
+  const ROW_SIZE = IMG_SIZE / NUM_ROWS_COLS
+  canvas.width = IMG_SIZE
+  canvas.height = IMG_SIZE
+  document.body.append(canvas)
+  const ctx = canvas.getContext('2d')!
+  const EDGE_ANCHOR_SIZE = 6
+  rects.forEach((rect, i) => {
+    const frame = { x: rect.x * COL_SIZE, y: rect.y * ROW_SIZE, w: rect.w * COL_SIZE, h: rect.h * ROW_SIZE }
+    const { x, y, w, h } = frame
+    anchorDemoAtlas.frames.push({ filename: 'rect_' + i.toString().padStart(4, '0'), frame })
+    ctx.fillStyle = `#222`
+    ctx.fillRect(x, y, w, h)
+
+    ctx.fillStyle = '#999'
+    ctx.fillRect(x + w * 0.5 - EDGE_ANCHOR_SIZE * 0.5, y + h * 0.5 - EDGE_ANCHOR_SIZE * 0.5, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+
+    ctx.fillRect(x, y, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w * 0.5 - EDGE_ANCHOR_SIZE * 0.5, y, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w - EDGE_ANCHOR_SIZE, y, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+
+    ctx.fillRect(x, y + h * 0.5 - EDGE_ANCHOR_SIZE * 0.5, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w - EDGE_ANCHOR_SIZE, y + h * 0.5 - EDGE_ANCHOR_SIZE * 0.5, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+
+    ctx.fillRect(x, y + h - EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w * 0.5 - EDGE_ANCHOR_SIZE * 0.5, y + h - EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w - EDGE_ANCHOR_SIZE, y + h - EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+  })
+  const imgData = canvas.toDataURL()
+  canvas.parentElement?.removeChild(canvas)
+  return imgData
+})()
+</script>
+
+<template>
+  <TresLeches style="position:absolute; left:10px; top:10px;" />
+  <TresCanvas clear-color="#82DBC5">
+    <TresPerspectiveCamera :position="[5, 1, 5]" :look-at="[-2, 0, 0]" />
+    <OrbitControls />
+    <TresGroup :position-x="2">
+      <Line2 :points="[[-0.25, 0, 0], [0.25, 0, 0]]" :line-width="1" color="#FF0000" />
+      <Line2 :points="[[0, -0.25, 0], [0, 0.25, 0]]" :line-width="1" color="#00FF00" />
+      <Line2 :points="[[0, 0, -0.25], [0, 0, 0.25]]" :line-width="1" color="#0000FF" />
+   <Suspense>
+        <AnimatedSprite :image="anchorDemoImgData" :atlas="anchorDemoAtlas" animation="rect"
+          :anchor="[anchorX.value, anchorY.value]" :fps="fps.value" />
+      </Suspense>
+      <TresGridHelper :args="[10, 10]" />
+    </TresGroup>
+  </TresCanvas>
+</template>

--- a/docs/.vitepress/theme/components/AnimatedSpriteDemo.vue
+++ b/docs/.vitepress/theme/components/AnimatedSpriteDemo.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+import { AnimatedSprite, OrbitControls } from '@tresjs/cientos'
+</script>
+
+<template>
+  <TresLeches />
+  <TresCanvas clear-color="#82DBC5">
+    <OrbitControls />
+    <TresPerspectiveCamera :position="[0, 0, 5]"/>
+    <Suspense>
+      <AnimatedSprite
+        image="https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/namedAnimationsTexture.png"
+        atlas="https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/namedAnimationsAtlas.json"
+        animation="yes" :fps="10" :loop="true" />
+    </Suspense>
+  </TresCanvas>
+</template>

--- a/docs/.vitepress/theme/components/AnimatedSpriteNoAtlasDemo.vue
+++ b/docs/.vitepress/theme/components/AnimatedSpriteNoAtlasDemo.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+import { AnimatedSprite } from '@tresjs/cientos'
+</script>
+
+<template>
+  <TresCanvas clear-color="#82DBC5">
+    <TresPerspectiveCamera :position="[0, 0, 5]"/>
+    <Suspense>
+      <AnimatedSprite 
+        image="https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/textureWithoutAtlas.png"
+        :atlas="16" 
+        :animation="[0,15]"
+        :fps="10"
+        />
+    </Suspense>
+  </TresCanvas>
+</template>

--- a/docs/guide/abstractions/animated-sprite.md
+++ b/docs/guide/abstractions/animated-sprite.md
@@ -1,0 +1,131 @@
+# AnimatedSprite
+
+<DocsDemo>
+  <AnimatedSpriteDemo />
+</DocsDemo>
+
+`<AnimatedSprite />` allows you to use 2D animations defined in a [texture atlas](https://en.wikipedia.org/wiki/Texture_atlas). A typical `<AnimatedSprite />` will use:
+
+* an image containing multiple sprites
+* a JSON atlas containing the coordinates of the image
+
+## Usage
+
+<<< @/.vitepress/theme/components/AnimatedSpriteDemo.vue{3,11-16}
+
+::: warning Suspense
+`<AnimatedSprite />` loads resources asynchronously, so it must be wrapped in a `<Suspense />`.
+:::
+
+## Props
+
+<CientosPropsTable 
+component-path="src/core/abstractions/AnimatedSprite/component.vue" 
+:fields="['name', 'description', 'default', 'required']"
+:on-format-value="({valueFormatted, propName, fieldName, getFieldFormatted})=> {
+  if (fieldName === 'description') {
+    let type = getFieldFormatted('type')
+    if (type.indexOf('TSFunctionType') !== -1 && propName.startsWith('on')) {
+      type = '<code>(frameName:string) => void</code>'
+    }
+    return type + ' – ' + valueFormatted
+  }
+}"
+ />
+
+## `animation`
+
+The `animation` prop holds either the name of the currently playing animation or a range of frames to play, or a frame number to display.
+
+### Named animations
+
+Frames are automatically grouped into named animations, if you use either of the following naming conventions for your source images:
+
+* `[key][frame number].[file_extension]`
+* `[key]_[frame number].[file_extension]`
+
+The `<AnimatedSprite />` will automatically make all [key] available for playback as named animations.
+
+#### Example
+
+Here are some example source image names, to be compiled into an image texture and atlas.
+
+* heroIdle00.png
+* heroIdle01.png
+* heroIdle02.png
+* heroRun00.png
+* heroRun01.png
+* heroRun02.png
+* heroRun03.png
+* heroHeal00.png
+* heroHeal01.png
+
+When the resulting image texture and atlas are provided to `<AnimatedSprite />`, "heroIdle", "heroRun", and "heroHeal" will be available as named animations. Animation names can be used as follows:
+
+```vue{3}
+<AnimatedSprite 
+atlas="..." image="..." 
+animation="heroRun" 
+/>
+```
+
+### Ranges
+
+A `[number, number]` range can be supplied as the `animation` prop. The numbers correspond to the position of the frame in the `atlas` `frames` array, starting with `0`. The first `number` in the range represents the start frame of the animation. The last `number` represents the end frame.
+
+### Single frame
+
+To display a single animation frame, a `number` can be supplied as the `animation` prop. The `number` corresponds to the position of the frame in the `atlas` `frames` array, starting with `0`. 
+
+## `anchor`
+
+The `anchor` allow you to control how differently sized source images "grow" and "shrink". Namely, they "grow out from" and "shrink towards" the anchor. `[0, 0]` places the anchor at the top left corner of the `<AnimatedSprite />`. `[1,1]` places the anchor at the bottom right corner. By default, the anchor is placed at `[0.5, 0.5]` i.e., the center.
+
+Below is a simple animation containing differently sized source images. The anchor is visible at world position `0, 0, 0`.
+<DocsDemo>
+  <AnimatedSpriteAnchorDemo />
+</DocsDemo>
+
+::: warning
+Changing the anchor from the default can have unpredictable results if `asSprite` is `true`.
+:::
+
+## `definitions`
+
+For each [named animation](#named-animations), you can supply a "definition" that specifies frame order and repeated frames (delays). For the [named animation example above](#named-animations), the `definitions` prop might look like this:
+
+```vue
+<AnimatedSprite 
+atlas="..." image="..."
+:definitions="{
+  'heroIdle':'0(5),1-2', // repeat frame 0 five times, then play frames 1-2
+  'heroRun':'0-3,2-1', // play frames 0-3, then 2-1
+  // no "heroHeal" definition; the default frame order will be used: 0-1
+}"
+/>
+```
+
+## Compiling an atlas
+
+In typical usage, `<AnimatedSprite/>` requires both the URL to a texture of compiled sprite images and a JSON atlas containing information about the sprites in the texture.
+
+* [example compiled texture](https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/namedAnimationsTexture.png)
+* [example JSON atlas](https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/namedAnimationsAtlas.json)
+
+Compiling source images into a texture atlas is usually handled by third-party software. You may find [TexturePacker](https://www.codeandweb.com/texturepacker) useful.
+
+## Without an atlas
+
+There may be cases where you don't want to supply a generated JSON atlas as an `atlas` prop. This is possible if you compile your source images in a single row of equally sized columns *and* set the `atlas` prop to the number of columns.
+
+### Example
+
+This image is comprised of 16 source images, compiled into a single image, in a single row:
+
+<img src="https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/textureWithoutAtlas.png" />
+
+<DocsDemo>
+  <AnimatedSpriteNoAtlasDemo />
+</DocsDemo>
+
+<<< @/.vitepress/theme/components/AnimatedSpriteNoAtlasDemo.vue{12,13}

--- a/playground/src/pages/abstractions/AnimatedSprite.vue
+++ b/playground/src/pages/abstractions/AnimatedSprite.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+import { OrbitControls, AnimatedSprite } from '@tresjs/cientos'
+import { BasicShadowMap, SRGBColorSpace, NoToneMapping } from 'three'
+import { shallowReactive } from 'vue'
+import { TresLeches, useControls } from '@tresjs/leches'
+import '@tresjs/leches/styles'
+import { TexturePackerFrameDataArray } from '../../../../src/core/abstractions/AnimatedSprite/Atlas'
+
+const gl = {
+  clearColor: '#82DBC5',
+  shadows: true,
+  alpha: false,
+  shadowMapType: BasicShadowMap,
+  outputColorSpace: SRGBColorSpace,
+  toneMapping: NoToneMapping,
+}
+
+const animationState = shallowReactive({
+  fps: 10,
+  animation: "yes",
+  flipX: false,
+  asSprite: false,
+  loop: true,
+  reversed: false,
+  resetOnEnd: false,
+  anchorX: 0.5,
+  anchorY: 0.5
+})
+
+const { fps, animation, flipX, asSprite, loop, reversed, resetOnEnd, anchorX, anchorY } = useControls({
+  fps: { value: animationState.fps, min: 0, max: 120, step: 1 },
+  animation: { label: "Suzanne animation", value: animationState.animation, options: ["yes", "no"] },
+  flipX: animationState.flipX,
+  asSprite: animationState.asSprite,
+  loop: animationState.loop,
+  reversed: animationState.reversed,
+  resetOnEnd: animationState.resetOnEnd,
+  anchorX: { value: animationState.anchorX, min: 0, max: 1, step: 0.01 },
+  anchorY: { value: animationState.anchorY, min: 0, max: 1, step: 0.01 },
+})
+
+const anchorDemoAtlas: TexturePackerFrameDataArray = { frames: [] }
+const anchorDemoImgData = (() => {
+  const NUM_ROWS_COLS = 32
+  const rects: { x: number, y: number, w: number, h: number }[] = []
+  let h = 1
+  for (let r = 0; r < NUM_ROWS_COLS; r += h) {
+    let w = 1
+    for (let c = 0; c < NUM_ROWS_COLS; c += w) {
+      if (Math.random() > 0.6) {
+        w++
+      }
+      if (c + w >= NUM_ROWS_COLS) {
+        w = NUM_ROWS_COLS - c
+      }
+      if (Math.random() > 0.9) {
+        h++
+      }
+      if (r + h >= NUM_ROWS_COLS) {
+        h = NUM_ROWS_COLS - r
+      }
+      rects.push({ x: c, y: r, w, h })
+    }
+  }
+
+  const canvas = document.createElement('canvas')
+  const IMG_SIZE = 2048
+  const COL_SIZE = IMG_SIZE / NUM_ROWS_COLS
+  const ROW_SIZE = IMG_SIZE / NUM_ROWS_COLS
+  canvas.width = IMG_SIZE
+  canvas.height = IMG_SIZE
+  document.body.append(canvas)
+  const ctx = canvas.getContext('2d')!
+  const EDGE_ANCHOR_SIZE = 6
+  const CENTER_ANCHOR_SIZE = COL_SIZE
+  rects.forEach((rect, i) => {
+    const frame = { x: rect.x * COL_SIZE, y: rect.y * ROW_SIZE, w: rect.w * COL_SIZE, h: rect.h * ROW_SIZE }
+    const { x, y, w, h } = frame
+    anchorDemoAtlas.frames.push({ filename: 'rect_' + i.toString().padStart(4, '0'), frame })
+    ctx.fillStyle = `hsl(${360 * i / rects.length}, 100%, 50%)`
+    ctx.fillRect(x, y, w, h)
+
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)'
+    ctx.fillRect(x + w * 0.5 - CENTER_ANCHOR_SIZE * 0.5, y + h * 0.5 - CENTER_ANCHOR_SIZE * 0.5, CENTER_ANCHOR_SIZE, CENTER_ANCHOR_SIZE)
+
+    ctx.fillStyle = '#FFF'
+    ctx.textAlign = 'center'
+    ctx.font = '12px monospace'
+    ctx.textBaseline = 'middle'
+    ctx.fillText('Frame ' + i, x + w * 0.5, y + h * 0.5)
+
+    ctx.fillStyle = '#FFF'
+    ctx.fillRect(x, y, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w * 0.5 - EDGE_ANCHOR_SIZE * 0.5, y, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w - EDGE_ANCHOR_SIZE, y, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+
+    ctx.fillRect(x, y + h * 0.5 - EDGE_ANCHOR_SIZE * 0.5, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w - EDGE_ANCHOR_SIZE, y + h * 0.5 - EDGE_ANCHOR_SIZE * 0.5, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+
+    ctx.fillRect(x, y + h - EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w * 0.5 - EDGE_ANCHOR_SIZE * 0.5, y + h - EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+    ctx.fillRect(x + w - EDGE_ANCHOR_SIZE, y + h - EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE, EDGE_ANCHOR_SIZE)
+
+  })
+  const imgData = canvas.toDataURL()
+  canvas.parentElement?.removeChild(canvas)
+  return imgData
+})()
+</script>
+
+<template>
+  <TresLeches />
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera :position="[11, 11, 11]" />
+    <OrbitControls />
+    <Suspense>
+      <AnimatedSprite :image="anchorDemoImgData" :atlas="anchorDemoAtlas" animation="rect" :flip-x="flipX.value"
+        :fps="fps.value" :loop="loop.value" :reset-on-end="resetOnEnd.value" :anchor="[anchorX.value, anchorY.value]"
+        :as-sprite="asSprite.value" :reversed="reversed.value" />
+    </Suspense>
+    <Suspense>
+      <AnimatedSprite 
+        :position="[4, 0, 0]" 
+        image="https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/namedAnimationsTexture.png"
+        atlas="https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/namedAnimationsAtlas.json"
+        :animation="animation.value" 
+        :flip-x="flipX.value" 
+        :fps="fps.value" 
+        :loop="loop.value" 
+        :reset-on-end="resetOnEnd.value"
+        :anchor="[anchorX.value, anchorY.value]" 
+        :as-sprite="asSprite.value"
+        :reversed="reversed.value"
+        />
+    </Suspense>
+    <Suspense>
+      <AnimatedSprite 
+        :position="[-4, 0, 0]" 
+        image="https://raw.githubusercontent.com/Tresjs/assets/6c0b087768a0a2b76148c99fc87d7e6ddc3c6d66/textures/animated-sprite/textureWithoutAtlas.png"
+        :atlas="((): string[] => new Array(16).fill('heart'))()"
+        :flip-x="flipX.value" 
+        :fps="fps.value" 
+        :loop="loop.value" 
+        :reset-on-end="resetOnEnd.value"
+        :anchor="[anchorX.value, anchorY.value]" 
+        :as-sprite="asSprite.value"
+        :reversed="reversed.value"
+        animation="heart"
+        />
+    </Suspense>
+    <TresGridHelper :args="[10, 10]" />
+  </TresCanvas>
+</template>

--- a/playground/src/router/routes/abstractions.ts
+++ b/playground/src/router/routes/abstractions.ts
@@ -49,4 +49,9 @@ export const abstractionsRoutes = [
     name: 'Sampler',
     component: () => import('../../pages/abstractions/Sampler.vue'),
   },
+  {
+    path: '/abstractions/animated-sprite',
+    name: 'AnimatedSprite',
+    component: () => import('../../pages/abstractions/AnimatedSprite.vue'),
+  },
 ]

--- a/src/core/abstractions/AnimatedSprite/Atlas.ts
+++ b/src/core/abstractions/AnimatedSprite/Atlas.ts
@@ -1,0 +1,271 @@
+import type { Texture } from "three";
+import { TextureLoader } from "three";
+import { useLoader, useLogger } from "@tresjs/core";
+import { getNumbersFromEnd, stripUnderscoresNumbersFromEnd } from "./StringOps";
+import { expand } from "./AtlasAnimationDefinitionParser";
+
+export interface AtlasFrame {
+  name: string;
+  width: number;
+  height: number;
+  offsetX: number;
+  offsetY: number;
+  repeatX: number;
+  repeatY: number;
+}
+
+export interface AtlasPage {
+  frames: AtlasFrame[];
+  namedFrames: Record<string, AtlasFrame[]>;
+  texture: Texture;
+}
+
+export async function getAtlasPageAsync(
+  atlas: string | number | string[] | TexturePackerFrameDataArray | TexturePackerFrameDataObject,
+  image: string,
+  definitions?: Record<string, string>
+): Promise<AtlasPage> {
+  const texturePromise = useLoader(TextureLoader, image);
+  const atlasPromise =
+    typeof atlas === "string"
+      ? fetch(atlas)
+          .then((response) => response.json())
+          .catch((e) => useLogger().logError("Cientos Atlas - " + e))
+      : new Promise((resolve) => resolve(atlas));
+
+  const pagePromise = Promise.all([atlasPromise, texturePromise]).then(
+    (response) => {
+      const texture: Texture = response[1];
+      const processingFn = (() => {
+        if (typeof atlas === "string" || atlas.hasOwnProperty("frames")) {
+          return framesFromTexturePackerData;
+        } else if (typeof atlas === "number") {
+          return framesFromNumColsWidthHeight;
+        } else {
+          return framesFromAnimationNamesWidthHeight;
+        }
+      })();
+      const frames = processingFn(
+        response[0],
+        texture.image.width,
+        texture.image.height
+      );
+      const namedFrames = groupFramesByKey(frames);
+      texture.matrixAutoUpdate = false;
+      const page: AtlasPage = { frames, namedFrames, texture };
+      if (definitions) {
+        setDefinitions(page, definitions);
+      }
+      return page;
+    }
+  );
+
+  return pagePromise;
+}
+
+export type TexturePackerFrameData = {
+  filename: string;
+  frame: { x: number; y: number; w: number; h: number };
+};
+
+export type TexturePackerFrameDataArray = {
+  frames: TexturePackerFrameData[];
+};
+
+export type TexturePackerFrameDataObject = {
+  frames: Record<string, TexturePackerFrameData>;
+};
+
+function framesFromTexturePackerData(
+  data: TexturePackerFrameDataArray | TexturePackerFrameDataObject,
+  width: number,
+  height: number
+) {
+  return Array.isArray(data.frames)
+    ? framesFromTexturePackerDataArray(
+        data as TexturePackerFrameDataArray,
+        width,
+        height
+      )
+    : framesFromTexturePackerDataObject(
+        data as TexturePackerFrameDataObject,
+        width,
+        height
+      );
+}
+
+function framesFromTexturePackerDataArray(
+  data: TexturePackerFrameDataArray,
+  width: number,
+  height: number
+): AtlasFrame[] {
+  const invWidth = 1 / width;
+  const invHeight = 1 / height;
+  return data.frames.map((d) => ({
+    name: d.filename,
+    offsetX: d.frame.x * invWidth,
+    offsetY: 1 - (d.frame.y + d.frame.h) * invHeight,
+    repeatX: d.frame.w * invWidth,
+    repeatY: d.frame.h * invHeight,
+    width: d.frame.w,
+    height: d.frame.h,
+  }));
+}
+
+function framesFromTexturePackerDataObject(
+  data: TexturePackerFrameDataObject,
+  width: number,
+  height: number
+): AtlasFrame[] {
+  const invWidth = 1 / width;
+  const invHeight = 1 / height;
+  return Object.entries(data.frames).map(([k, v]) => ({
+    name: k,
+    offsetX: v.frame.x * invWidth,
+    offsetY: 1 - (v.frame.y + v.frame.h) * invHeight,
+    repeatX: v.frame.w * invWidth,
+    repeatY: v.frame.h * invHeight,
+    width: v.frame.w,
+    height: v.frame.h,
+  }));
+}
+
+function framesFromNumColsWidthHeight(
+  numCols: number,
+  width: number,
+  height: number,
+  name = "default"
+): AtlasFrame[] {
+  const frameWidth = width / numCols;
+  const invWidth = 1 / width;
+  const padAmount = numCols.toString().length;
+  return new Array(numCols).fill(0).map((_, i) => ({
+    name: name + String(i).padStart(padAmount, "0"),
+    offsetX: i * frameWidth * invWidth,
+    offsetY: 0,
+    repeatX: 1 / numCols,
+    repeatY: 1,
+    width: width / numCols,
+    height,
+  }));
+}
+
+function framesFromAnimationNamesWidthHeight(
+  animationNames: string[],
+  width: number,
+  height: number
+): AtlasFrame[] {
+  const numCols = animationNames.length;
+  const frames = framesFromNumColsWidthHeight(numCols, width, height);
+  const padAmount = numCols.toString().length;
+  animationNames.forEach((name, i) => {
+    frames[i].name = name + "_" + String(i).padStart(padAmount, "0");
+  });
+  return frames;
+}
+
+function setDefinitions(page: AtlasPage, definitions: Record<string, string>) {
+  for (const [animationName, definitionStr] of Object.entries(definitions)) {
+    const frames: AtlasFrame[] = getFrames(page, animationName);
+    const expanded = expand(definitionStr);
+    for (const i of expanded) {
+      if (i < 0 || frames.length <= i) {
+        useLogger().logError(
+          `Cientos Atlas: Attempting to access frame index ${i} in animation ${animationName}, but it does not exist.`
+        );
+      }
+    }
+    page.namedFrames[animationName] = expanded.map((i) => frames[i]);
+  }
+}
+
+export function getFrames(
+  page: AtlasPage,
+  animationNameOrFrameNumber: string | number | [number, number]
+): AtlasFrame[] {
+  if (typeof animationNameOrFrameNumber === "string")
+    return getFramesByName(page, animationNameOrFrameNumber);
+  else if (typeof animationNameOrFrameNumber === "number")
+    return getFramesByIndices(
+      page,
+      animationNameOrFrameNumber,
+      animationNameOrFrameNumber
+    );
+  else {
+    return getFramesByIndices(
+      page,
+      animationNameOrFrameNumber[0],
+      animationNameOrFrameNumber[1]
+    );
+  }
+}
+
+function getFramesByName(page: AtlasPage, name: string): AtlasFrame[] {
+  if (!(name in page.namedFrames)) {
+    useLogger().logError(
+      `Cientos Atlas: getFramesByName – name ${name} does not exist in page. Available names: ${Object.keys(
+        page
+      )}`
+    );
+  }
+  return page.namedFrames[name];
+}
+
+function getFramesByIndices(
+  page: AtlasPage,
+  startI: number,
+  endI: number
+): AtlasFrame[] {
+  if (
+    startI < 0 ||
+    page.frames.length <= startI ||
+    endI < 0 ||
+    page.frames.length <= endI
+  ) {
+    useLogger().logError(
+      `Cientos Atlas: getFramesByIndex – [${startI}, ${endI}] is out of bounds.`
+    );
+  }
+  const result = [];
+  const sign = Math.sign(endI - startI);
+  if (sign === 0) return [page.frames[startI]];
+  for (let i = startI; i !== endI + sign; i += sign) {
+    result.push(page.frames[i]);
+  }
+  return result;
+}
+
+/**
+ * @returns An object where all AtlasFrames with the same key are grouped in an ordered array by name in ascending value.
+ * A key is defined as an alphanumeric string preceding a trailing numeric string.
+ * E.g.:
+ * "hero0Idle" has no key as it does not have trailing numeric string.
+ * "heroIdle0" has the key "heroIdle".
+ * @example ```
+ * groupFramesByKey([{name: hero, ...}, {name: heroJump3, ...}, {name: heroJump0, ...}, {name: heroIdle0, ...}, {name: heroIdle1, ...}]) returns
+ * {
+ * heroJump: [{name: heroJump0, ...}, {name: heroJump3, ...}],
+ * heroIdle: [{name: heroIdle0, ...}, {name: heroIdle1, ...}]
+ * }
+ * ```
+ */
+function groupFramesByKey(frames: AtlasFrame[]): Record<string, AtlasFrame[]> {
+  const result: Record<string, AtlasFrame[]> = {};
+
+  for (const frame of frames) {
+    if (getNumbersFromEnd(frame.name) !== null) {
+      const key = stripUnderscoresNumbersFromEnd(frame.name);
+      if (result.hasOwnProperty(key)) {
+        result[key].push(frame);
+      } else {
+        result[key] = [frame];
+      }
+    }
+  }
+
+  for (const entry of Object.values(result)) {
+    entry.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return result;
+}

--- a/src/core/abstractions/AnimatedSprite/AtlasAnimationDefinitionParser.ts
+++ b/src/core/abstractions/AnimatedSprite/AtlasAnimationDefinitionParser.ts
@@ -1,0 +1,218 @@
+import { useLogger } from "@tresjs/core";
+
+/**
+ * Expand an animation definition string into an array of numbers.
+ * @param definitionStr - A comma-separated string of frame numbers with optional parentheses-surrounded durations.
+ * @example - expand("0,2") === [0,2]
+ * @example - expand("2(10)") === [2,2,2,2,2,2,2,2,2,2]
+ * @example - expand("1-4") === [1,2,3,4]
+ * @example - expand("10-5(2)") === [10,10,9,9,8,8,7,7,6,6,5,5]
+ * @example - expand("1-4(3),10(2)") === [1,1,1,2,2,2,3,3,3,4,4,4,10,10]
+ */
+
+export function expand(definitionStr: string) : number[] {
+  const parsed = parse(definitionStr)
+  const expanded: number[] = [];
+  for (const info of parsed) {
+    if (info.duration <= 0) {
+    } else if (info.endFrame < 0 || info.startFrame === info.endFrame) {
+        for (let _ = 0; _ < info.duration; _++) {
+          expanded.push(info.startFrame);
+        }
+        continue
+    } else {
+        const sign = Math.sign(info.endFrame - info.startFrame);
+        for (
+          let frame = info.startFrame;
+          frame !== info.endFrame + sign;
+          frame += sign
+        ) {
+          for (let _ = 0; _ < info.duration; _++) {
+            expanded.push(frame);
+          }
+        }
+    }
+  }
+  return expanded
+}
+
+type AnimationDefinition = {
+  startFrame: number,
+  endFrame: number,
+  duration: number
+}
+
+/**
+ * Parse an animation defintion string into an array of AnimationDefinition.
+ * @param definitionStr - A comma-separated string of frame numbers with optional parentheses-surrounded durations.
+ * @example - parse("0,2") === [{startFrame:0, endFrame:0, delay:1}, {startFrame:2, endFrame:2, delay:1}]
+ * @example - parse("2(10)") === [{startFrame:2, endFrame:2, delay:10}]
+ * @example - parse("1-4") === [{startFrame:1, endFrame:4, delay:1}]
+ * @example - parse("10-5(2)") === [{startFrame:10, endFrame:5, delay:2}]
+ * @example - parse("1-4(3),10(2)") === [{startFrame:1, endFrame:4, delay:3}, {startFrame:10, endFrame:10, delay:2}]
+ */
+
+export function parse(definitionStr: string) : AnimationDefinition[] {
+  let transition: Transition = "START_FRAME_IN";
+  const parsed: AnimationDefinition[] = [];
+  for (const token of tokenize(definitionStr)) {
+    if (transition === "START_FRAME_IN") {
+      if (token.name === "NUMBER") {
+        parsed.push({
+          startFrame: token.value,
+          endFrame: token.value,
+          duration: 1,
+        });
+        transition = "START_FRAME_OUT";
+      } else {
+        warnDefinitionSyntaxError(
+          "number",
+          token.name,
+          definitionStr,
+          token.startI
+        );
+      }
+    } else if (transition === "START_FRAME_OUT") {
+      if (token.name === "COMMA") {
+        transition = "START_FRAME_IN";
+      } else if (token.name === "HYPHEN") {
+        transition = "END_FRAME_IN";
+      } else if (token.name === "OPEN_PAREN") {
+        transition = "DURATION_IN";
+      } else {
+        warnDefinitionSyntaxError(
+          '",", "-", "("',
+          token.name,
+          definitionStr,
+          token.startI
+        );
+      }
+    } else if (transition === "END_FRAME_IN") {
+      if (token.name === "NUMBER") {
+        parsed[parsed.length - 1].endFrame = token.value;
+        transition = "END_FRAME_OUT";
+      } else {
+        warnDefinitionSyntaxError(
+          "number",
+          token.name,
+          definitionStr,
+          token.startI
+        );
+      }
+    } else if (transition === "END_FRAME_OUT") {
+      if (token.name === "COMMA") {
+        transition = "START_FRAME_IN";
+      } else if (token.name === "OPEN_PAREN") {
+        transition = "DURATION_IN";
+      } else {
+        warnDefinitionSyntaxError(
+          "',' or '('",
+          token.name,
+          definitionStr,
+          token.startI
+        );
+      }
+    } else if (transition === "DURATION_IN") {
+      if (token.name === "NUMBER") {
+        parsed[parsed.length - 1].duration = token.value;
+        transition = "DURATION_OUT";
+      } else {
+        warnDefinitionSyntaxError(
+          "number",
+          token.name,
+          definitionStr,
+          token.startI
+        );
+      }
+    } else if (transition === "DURATION_OUT") {
+      if (token.name === "CLOSE_PAREN") {
+        transition = "NEXT_OR_DONE";
+      } else {
+        warnDefinitionSyntaxError('"("', token.name, definitionStr, token.startI);
+      }
+    } else if (transition === "NEXT_OR_DONE") {
+      if (token.name === "COMMA") {
+        transition = "START_FRAME_IN";
+      } else {
+        warnDefinitionSyntaxError('","', token.name, definitionStr, token.startI);
+      }
+    }
+  }
+
+  return parsed;
+}
+
+type Transition =
+  | "START_FRAME_IN"
+  | "START_FRAME_OUT"
+  | "END_FRAME_IN"
+  | "END_FRAME_OUT"
+  | "DURATION_IN"
+  | "DURATION_OUT"
+  | "NEXT_OR_DONE";
+
+type TokenName = "COMMA" | "HYPHEN" | "OPEN_PAREN" | "CLOSE_PAREN" | "NUMBER";
+interface Token {
+  name: TokenName;
+  value: number;
+  startI: number;
+}
+
+function tokenize(definition: string): Token[] {
+  const tokenized: Token[] = [];
+  let ii = 0;
+  while (ii < definition.length) {
+    const c = definition[ii];
+    if ("0123456789".indexOf(c) > -1) {
+      if (
+        tokenized.length &&
+        tokenized[tokenized.length - 1].name === "NUMBER"
+      ) {
+        tokenized[tokenized.length - 1].value *= 10;
+        tokenized[tokenized.length - 1].value += parseInt(c);
+      } else {
+        tokenized.push({ name: "NUMBER", value: parseInt(c), startI: ii });
+      }
+    } else if (c === " ") {
+    } else if (c === ",") {
+      tokenized.push({ name: "COMMA", value: -1, startI: ii });
+    } else if (c === "(") {
+      tokenized.push({ name: "OPEN_PAREN", value: -1, startI: ii });
+    } else if (c === ")") {
+      tokenized.push({ name: "CLOSE_PAREN", value: -1, startI: ii });
+    } else if (c === "-") {
+      tokenized.push({ name: "HYPHEN", value: -1, startI: ii });
+    } else {
+      warnDefinitionBadCharacter("0123456789,-()", c, definition, ii);
+    }
+    ii++;
+  }
+
+  return tokenized;
+}
+
+function warnDefinitionBadCharacter(
+  expected: string,
+  found: string,
+  definition: string,
+  index: number
+) {
+  useLogger().logError(
+    `Cientos AnimationDefinitionParser: Unexpected character while processing animation definition: expected ${expected}, got ${found}.
+${definition}
+${Array(index + 1).join(" ")}^`
+  );
+}
+
+function warnDefinitionSyntaxError(
+  expected: string,
+  found: string,
+  definition: string,
+  index: number
+) {
+  useLogger().logError(
+    `Cientos AnimationDefinitionParser: Syntax error while processing animation definition: expected ${expected}, got ${found}.
+${definition}
+${Array(index + 1).join(" ")}^`
+  );
+}

--- a/src/core/abstractions/AnimatedSprite/StringOps.ts
+++ b/src/core/abstractions/AnimatedSprite/StringOps.ts
@@ -1,0 +1,14 @@
+const numbersAtEnd = /[0-9]*$/;
+const underscoresNumbersAtEnd = /_*[0-9]*$/;
+
+export function stripUnderscoresNumbersFromEnd(str: string) {
+  return str.replace(underscoresNumbersAtEnd, "");
+}
+
+export function getNumbersFromEnd(str: string) {
+  const matches = str.match(numbersAtEnd);
+  if (matches) {
+    return parseInt(matches[matches.length - 1]);
+  }
+  return null;
+}

--- a/src/core/abstractions/AnimatedSprite/component.vue
+++ b/src/core/abstractions/AnimatedSprite/component.vue
@@ -1,0 +1,222 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useRenderLoop } from '@tresjs/core'
+import type { Group, Mesh, MeshBasicMaterial, Sprite, SpriteMaterial } from 'three'
+import { DoubleSide } from 'three'
+import type { AtlasFrame, AtlasPage, TexturePackerFrameDataArray, TexturePackerFrameDataObject } from './Atlas'
+import { getAtlasPageAsync, getFrames } from './Atlas'
+
+export interface AnimatedSpriteProps {
+  /** The URL of the image texture or an image dataURL. */
+  image: string
+  /** If `string`, the URL of the JSON atlas. 
+   * If `number`, the number of columns in the texture. 
+   * If `string[]`, the animation names for each column in the texture. 
+   * If TexturePackerFrameDataArray or TexturePackerFrameDataObject, the atlas as a JS object.
+   **/
+  atlas: string | number | string[] | TexturePackerFrameDataArray | TexturePackerFrameDataObject
+  /** Specify playback frame order and repeated frames (delays). `definitions` is a record where keys are atlas animation names and values are strings containing an animation definition.
+  * A "animation definition" comma-separated string of frame numbers with optional parentheses-surrounded durations.
+  * Here is how various definition strings convert to arrays of frames for playback:
+  * * "0,2,1" - [0,2,1], i.e., play frame 0, 2, then 1.
+  * * "2(10)" - [2,2,2,2,2,2,2,2,2,2], i.e., play from 2 10 times.
+  * * "1-4" - [1,2,3,4]
+  * * "10-5(2)" - [10,10,9,9,8,8,7,7,6,6,5,5]
+  * * "1-4(3),10(2)" - [1,1,1,2,2,2,3,3,3,4,4,4,10,10]
+   */
+  definitions?: Record<string, string>
+  /** The desired frames per second of the animation. */
+  fps?: number
+  /** Whether or not the animation should loop. */
+  loop?: boolean
+  /** If a string, the name of the animation to play. If `[number, number]`, the start and end frames of the animation. If `number` the frame number to display. */
+  animation?: string | [number, number] | number
+  /** Event callback when the assets – atlas and image – are loaded. */
+  onLoad?: (frameName:string) => void
+  /** Event callback when the animation ends. */
+  onEnd?: (frameName:string) => void
+  /** Event callback when the animation loops. */
+  onLoopEnd?: (frameName:string) => void
+  /** Event callback when each frame changes. Note: called *at most* once per tick. */
+  onFrame?: (frameName:string) => void
+  /** Whether the animation is paused. */
+  paused?: boolean
+  /** Whether to play the animation in reverse. */
+  reversed?: boolean
+  /** Whether the sprite should be flipped, left to right. */
+  flipX?: boolean
+  /** For a non-looping animation, when the animation ends, whether to display the zeroth frame. */
+  resetOnEnd?: boolean
+  /** Alpha test value for the material. [See THREE.Material.alphaTest](https://threejs.org/docs/#api/en/materials/Material.alphaTest) */
+  alphaTest?: number
+  /** Whether to display the object as a THREE.Sprite. [See THREE.Sprite](https://threejs.org/docs/?q=sprite#api/en/objects/Sprite) */
+  asSprite?: boolean
+  /** The origin of the object. [0, 0] is left, top. [1, 1] is right, bottom. */
+  anchor?: [number, number]
+}
+
+const props = withDefaults(defineProps<AnimatedSpriteProps>(), {
+  fps: 60,
+  loop: true,
+  animation: 0,
+  paused: false,
+  reversed: false,
+  flipX: false,
+  alphaTest: 0.0,
+  resetOnEnd: false,
+  asSprite: false,
+  anchor: () => [0.5, 0.5],
+})
+
+const page:AtlasPage = await getAtlasPageAsync(props.atlas, props.image, props.definitions)
+
+const animatedSpriteGroupRef = ref<InstanceType<typeof Group> | null>()
+const animatedSpriteSpriteRef = ref<InstanceType<typeof Mesh> | InstanceType<typeof Sprite> | null>()
+const animatedSpriteMaterialRef = ref<InstanceType<typeof SpriteMaterial> | InstanceType<typeof MeshBasicMaterial> | null>()
+const scaleX = ref(0)
+const scaleY = ref(0)
+const positionX = ref(0)
+const positionY = ref(0)
+const NOMINAL_PX_TO_WORLD_UNITS = 0.01
+
+let frame: AtlasFrame | null = null
+let frameNum = 0
+let cooldown = 1
+let animation: AtlasFrame[] = getFrames(page, props.animation)
+let frameHeldOnLoopEnd = false
+
+updateFrame(animation[frameNum])
+
+if (props.onLoad) props.onLoad(frame!.name)
+
+useRenderLoop().onLoop(({ delta }) => {
+  if (!animatedSpriteSpriteRef.value) return
+  if (!props.paused && !frameHeldOnLoopEnd) {
+    cooldown -= delta * props.fps
+  }
+  while (cooldown <= 0) {
+    cooldown++
+
+    if (props.reversed) {
+      frameNum--
+      if (props.onLoopEnd && props.loop && frameNum <= 0) props.onLoopEnd(frame!.name)
+      if (!props.loop && frameNum < 0) {
+        frameHeldOnLoopEnd = true
+        frameNum = props.resetOnEnd ? animation.length - 1 : 0
+        if (props.onEnd) props.onEnd(frame!.name)
+      }
+      if (props.loop) {
+        while (frameNum < 0) {
+          frameNum += animation.length
+        }
+      } else {
+        frameNum = Math.max(0, frameNum)
+      }
+    } else {
+      frameNum++
+      if (props.onLoopEnd && props.loop && frameNum >= animation.length) props.onLoopEnd(frame!.name)
+      if (!props.loop && frameNum >= animation.length) {
+        frameHeldOnLoopEnd = true
+        frameNum = props.resetOnEnd ? 0 : animation.length - 1
+        if (props.onEnd) props.onEnd(frame!.name)
+      }
+      if (props.loop) {
+        frameNum %= animation.length
+      } else {
+        frameNum = Math.min(animation.length - 1, frameNum)
+      }
+    }
+  }
+
+  updateFrame(animation[frameNum])
+})
+
+function updateFrame(newFrame: AtlasFrame) {
+  if (newFrame !== frame) {
+    frame = newFrame
+    if (props.onFrame) props.onFrame(frame.name)
+    render()
+  }
+}
+
+function render() {
+  if (!animatedSpriteMaterialRef.value || !frame) {
+    frame = null
+    return
+  }
+
+  page.texture.offset.x = frame.offsetX + (props.flipX ? frame.repeatX : 0)
+  page.texture.offset.y = frame.offsetY
+  page.texture.repeat.x = frame.repeatX * (props.flipX ? -1 : 1)
+  page.texture.repeat.y = frame.repeatY
+
+  page.texture.updateMatrix()
+
+  scaleX.value = frame.width * NOMINAL_PX_TO_WORLD_UNITS
+  scaleY.value = frame.height * NOMINAL_PX_TO_WORLD_UNITS
+
+  positionX.value = -(props.anchor[0] - 0.5) * frame.width * NOMINAL_PX_TO_WORLD_UNITS
+  positionY.value = (props.anchor[1] - 0.5) * frame.height * NOMINAL_PX_TO_WORLD_UNITS
+};
+
+watch(() => props.animation, (newValue, oldValue) => {
+  if (JSON.stringify(newValue) === JSON.stringify(oldValue)) {
+    return
+  }
+  animation = getFrames(page, props.animation)
+  frameNum = 0
+  cooldown = 1
+  updateFrame(animation[frameNum])
+  frameHeldOnLoopEnd = false
+}, { immediate: true })
+
+watch(() => props.paused, () => {
+  frameHeldOnLoopEnd = false
+})
+
+watch(() => props.loop, () => {
+  if (frameHeldOnLoopEnd && props.loop) frameHeldOnLoopEnd = false
+})
+
+/*
+ * NOTE: If the frame is being held because the animation ran to the end and does not loop,
+ * allow resetOnEnd to modify the displayed frame.
+ */
+watch(() => [props.resetOnEnd, props.reversed], () => {
+  if (frameHeldOnLoopEnd) {
+    if (props.reversed) {
+      frameNum = props.resetOnEnd ? animation.length - 1 : 0
+    } else {
+      frameNum = props.resetOnEnd ? 0 : animation.length - 1
+    }
+    updateFrame(animation[frameNum])
+  }
+})
+
+watch(() => [props.flipX, props.anchor, animatedSpriteSpriteRef], render)
+
+defineExpose({
+  value: animatedSpriteGroupRef
+})
+</script>
+
+<template>
+  <TresGroup ref="animatedSpriteGroupRef" v-model="props">
+    <Suspense :fallback="null">
+      <template v-if="props.asSprite">
+        <TresSprite ref="animatedSpriteSpriteRef" :scale="[scaleX, scaleY, 1]" :position="[positionX, positionY, 0]">
+          <TresSpriteMaterial ref="animatedSpriteMaterialRef" :toneMapped="false" :map="page.texture" :transparent="true"
+            :alphaTest="props.alphaTest" />
+        </TresSprite>
+      </template>
+      <template v-else>
+        <TresMesh ref="animatedSpriteSpriteRef" :scale="[scaleX, scaleY, 1]" :position="[positionX, positionY, 0]">
+          <TresPlaneGeometry :args="[1, 1]" />
+          <TresMeshBasicMaterial ref="animatedSpriteMaterialRef" :toneMapped="false" :side="DoubleSide" :map="page.texture"
+            :transparent="true" :alphaTest="props.alphaTest" />
+        </TresMesh>
+      </template>
+    </Suspense>
+    {children}
+  </TresGroup>
+</template>

--- a/src/core/abstractions/index.ts
+++ b/src/core/abstractions/index.ts
@@ -7,6 +7,7 @@ import { GlobalAudio } from './GlobalAudio'
 import Lensflare from './Lensflare/component.vue'
 import Fbo from './useFBO/component.vue'
 import Sampler from './useSurfaceSampler/component.vue'
+import AnimatedSprite from './AnimatedSprite/component.vue'
 
 export * from './useFBO/'
 export * from './useSurfaceSampler'
@@ -21,4 +22,5 @@ export {
   GlobalAudio,
   Fbo,
   Sampler,
+  AnimatedSprite,
 }


### PR DESCRIPTION
@JaimeTorrealba , @alvarosabu 

I wonder if you guys would take a look at `<AnimatedSprite />` and give me some feedback. 

Docs: `pnpm run docs:dev` and then => http://localhost:5173/guide/abstractions/animated-sprite.html
Playground: `pnpm run playground` and then => http://localhost:5173/abstractions/animated-sprite

## What do you think of the API?

I'd like to know if you see any improvements to make to the API. I followed most of what Drei did, but included a few extra things that I picked up from using [Deepnight's gameBase](https://github.com/deepnight/gameBase). Maybe those changes aren't necessary here – What do you think?

In particular, these props:

* anchor – this allows differently sized images to be used in an atlas
* definitions – this allows users to specify how each animation plays: frame order and delays. I think it's really handy for tweaking animations on the fly, but it does add about 200 lines of code, mostly for the definition parser.
* animation – named animations are pulled from source image names. See guide/abstractions/animated-sprite.html#animation . I found this really handy when working with the gamebase, but maybe our users won't see the point.

## Do we want to include a spritesheet compiler?

A while ago, I wrote a very dumb node.js command line app for compiling spritesheets/atlas JSON from source images. I could rewrite it for the browser and include it in the docs. That would let users compile their own spritesheets/atlas JSON online with a drag and drop interface. But do we want to support that going forward?

TexturePacker is paid software. For context, Drei and our `<AnimatedSprite />` read simple TexturePacker atlas JSON. 
But Drei and our `<AnimatedSprite />` don't/won't support most of the advanced features of TexturePacker.