### PR TITLE
chore(useGLTF): fix linter errors

### DIFF
--- a/src/core/loaders/useGLTF/index.ts
+++ b/src/core/loaders/useGLTF/index.ts
@@ -66,11 +66,11 @@ export async function useGLTF<T extends string | string[]>(
   options: GLTFLoaderOptions = {
     draco: false,
   },
-  extendLoader?: (loader: GLTFLoader) => void
+  extendLoader?: (loader: GLTFLoader) => void,
 ): Promise<T extends string[] ? GLTFResult[] : GLTFResult> {
   return await useLoader(
     GLTFLoader,
     path,
-    setExtensions(options, extendLoader)
-  );
+    setExtensions(options, extendLoader),
+  )
 }


### PR DESCRIPTION
## Problem

Changes to src/core/loaders/useGLTF/index.ts are causing the CI/CD linter to fail. The changes were merged to `main`, so fresh PRs based on up-to-date `main` also throw errors.

## Solution

`pnpm run lint --fix` on `main`