### PR TITLE
docs: add an example of clicking on an ingested model to move

### DIFF
--- a/playground/src/components/ModelsDemo.vue
+++ b/playground/src/components/ModelsDemo.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRenderLoop } from '@tresjs/core'
-import { useGLTF, GLTFModel, useFBX, FBXModel } from '@tresjs/cientos'
+import { useGLTF, GLTFModel, useFBX, FBXModel, Text3D } from '@tresjs/cientos'
 import { NoToneMapping } from 'three'
 
 const modelPath = 'https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/aku-aku/AkuAku.gltf'
 const modelPathFbx = 'https://raw.githubusercontent.com/Tresjs/assets/main/models/fbx/low-poly-truck/Jeep_done.fbx'
+const fontPath = 'https://raw.githubusercontent.com/Tresjs/assets/main/fonts/FiraCodeRegular.json'
 
 const { scene: model } = await useGLTF(modelPath, {
   draco: true,
@@ -14,6 +15,7 @@ const { scene: model } = await useGLTF(modelPath, {
 const modelFbx = await useFBX(modelPathFbx)
 
 const akuAkuRef = ref(null)
+const akuAkuRef2 = ref(null)
 const jeepRef = ref(null)
 
 const gl = {
@@ -32,6 +34,12 @@ onLoop(() => {
     jeepRef.value.value.rotation.y -= 0.01
   }
 })
+
+const moveMask = () => {
+  if (akuAkuRef2.value) {
+    akuAkuRef2.value.value.position.z += 0.1
+  }
+}
 </script>
 
 <template>
@@ -51,6 +59,41 @@ onLoop(() => {
         cast-shadow
       />
     </Suspense>
+    <Suspense>
+      <Text3D
+        text="Click to move mask"
+        :size="0.3"
+        :font="fontPath"
+        center
+        :need-updates="true"
+        :position="[0, 6.4, 2]"
+      />
+    </Suspense>
+    <Suspense>
+      <GLTFModel
+        ref="akuAkuRef2"
+        :path="modelPath"
+        draco
+        :position="[0, 1, 2]"
+        name="Aku_aku"
+        cast-shadow
+      />
+    </Suspense>
+    <TresMesh
+      :position="[0, 3.4, 2]"
+      @click="(intersection) => {
+        const object = intersection.object as THREE.Mesh;
+        object.position.z += 0.1;
+        moveMask();
+      }"
+    >
+      <TresBoxGeometry :args="[2, 3, 1]" />
+      <TresMeshBasicMaterial 
+        color="white" 
+        :opacity="0" 
+        :transparent="true" 
+      />
+    </TresMesh>
     <!-- FBX MODELS -->
     <primitive
       :object="modelFbx"


### PR DESCRIPTION
# Background

There are no "@click" click events on GLTFModel, and sometimes using await directly in the composite API will give an error.

# Realize

Add a transparent cube that moves synchronously with the model, and click events act directly on the cube