### PR TITLE
fix: line2 cannot dynamically add the count of points

### DIFF
--- a/src/core/shapes/Line2.vue
+++ b/src/core/shapes/Line2.vue
@@ -66,7 +66,7 @@ function getInterpolatedVertexColors(vertexColors: VertexColors | null, numPoint
   return iColors
 }
 
-function updateLineGeometry(geometry: LineGeometry, points: Points, vertexColors: VertexColors | null) {
+function updateLineGeometry(geometry: LineGeometry & { _maxInstanceCount?: number }, points: Points, vertexColors: VertexColors | null) {
   const pValues = points.map((p) => {
     if (p instanceof Vector3) {
       return [p.x, p.y, p.z]
@@ -81,7 +81,9 @@ function updateLineGeometry(geometry: LineGeometry, points: Points, vertexColors
       return p
     }
   }).flat()
-  geometry.setPositions(pValues.flat())
+  const flatPositions = pValues.flat()
+  geometry.setPositions(flatPositions)
+  geometry._maxInstanceCount = flatPositions.length / 3
 
   const colors = getInterpolatedVertexColors(vertexColors, points.length).map(c => c.toArray()).flat()
   geometry.setColors(colors)
@@ -123,7 +125,6 @@ watch(() => [
   props.dashSize,
   props.dashOffset,
 ], () => updateLineMaterial(lineMaterial, props))
-watch([props.points, props.vertexColors], () => updateLineGeometry(lineGeometry, props.points, props.vertexColors))
 watch(() => props.vertexColors, () => updateLineGeometry(lineGeometry, props.points, props.vertexColors))
 watch(() => props.points, () => updateLineGeometry(lineGeometry, props.points, props.vertexColors))
 watch([sizes.height, sizes.width], () => lineMaterial.resolution = new Vector2(sizes.width.value, sizes.height.value))


### PR DESCRIPTION
In the original version, the change of line2 can only be based on the number of points during initialization. If you want to add the number of points later, it cannot be rendered correctly.

```vue
<template>
	<Line2
		:points="points"
		:line-width="20"
		color="#82dbc5"
	/>
</template>

<script setup lang="ts">
import {Line2} from '@tresjs/cientos'
import {shallowRef} from "vue";
import { useTresContext } from '@tresjs/core'
import {Vector2} from "three";

const {raycaster, scene} = useTresContext();

const points = shallowRef([[0, 0, 0], [1, 1, 1]])

const mousePoint = new Vector2();
document.body.addEventListener("click", e => {
	mousePoint.x = (e.clientX / window.innerWidth) * 2 - 1;
	mousePoint.y = -((e.clientY / window.innerHeight) * 2 - 1);
	raycaster.value.setFromCamera(mousePoint, raycaster.value.camera);
	const intersects = raycaster.value.intersectObjects(scene.value.children, true);

	if (intersects.length > 0) {
		const {x, y, z} = intersects[0].point;
		points.value = [...points.value, [x, y, z]];
	}
})
</script>
```
![eg](https://github.com/Tresjs/cientos/assets/46118247/14763248-0e27-4279-a313-e890bf97781b)
