### PR TITLE
fix: transformControls throws error when switching active camera

### DIFF
--- a/src/core/controls/TransformControls.vue
+++ b/src/core/controls/TransformControls.vue
@@ -88,5 +88,6 @@ onUnmounted(() => {
     :show-y="showY"
     :show-z="showZ"
     :visible="true"
+    :key="camera.uuid"
   />
 </template>

--- a/src/core/controls/TransformControls.vue
+++ b/src/core/controls/TransformControls.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ShallowRef } from 'vue'
 import { onUnmounted, shallowRef, watchEffect, toRefs } from 'vue'
-import type { Object3D, Event } from 'three'
+import type { Object3D, Camera, Event } from 'three'
 
 import { TransformControls } from 'three-stdlib'
 import { useEventListener } from '@vueuse/core'
@@ -9,6 +9,7 @@ import { useTresContext } from '@tresjs/core'
 
 export interface TransformControlsProps {
   object: Object3D
+  camera?: Camera
   mode?: string
   enabled?: boolean
   axis?: 'X' | 'Y' | 'Z' | 'XY' | 'YZ' | 'XZ' | 'XYZ'
@@ -40,7 +41,7 @@ const { object, mode, enabled, axis, translationSnap, rotationSnap, scaleSnap, s
 
 const controlsRef: ShallowRef<TransformControls | undefined> = shallowRef()
 
-const { controls, camera, renderer, extend } = useTresContext()
+const { controls, camera: activeCamera, renderer, extend } = useTresContext()
 
 extend({ TransformControls })
 
@@ -72,10 +73,11 @@ onUnmounted(() => {
 
 <template>
   <TresTransformControls
-    v-if="camera && renderer"
+    v-if="(camera || activeCamera) && renderer"
     ref="controlsRef"
+    :key="(camera || activeCamera)?.uuid"
     :object="object"
-    :args="[camera, renderer.domElement]"
+    :args="[camera || activeCamera, renderer.domElement]"
     :mode="mode"
     :enabled="enabled"
     :axis="axis"
@@ -88,6 +90,5 @@ onUnmounted(() => {
     :show-y="showY"
     :show-z="showZ"
     :visible="true"
-    :key="camera.uuid"
   />
 </template>


### PR DESCRIPTION
closes #366

Since TransformControls needs a camera in the constructor and I haven't found a way to change the camera once it is instantiated the solution I found is to add a :key to force it to be recreated.

This probably has to be considered for all components where the camera (or other dependencies) is used in the constructor and there is no proper way of setting it after it was created?