### PR TITLE
chore(docs): Fix typo `recieve-shadow` to `receive-shadow`

### DIFF
--- a/docs/guide/staging/backdrop.md
+++ b/docs/guide/staging/backdrop.md
@@ -15,7 +15,7 @@ The `cientos` package provides a `<Backdrop />` component. It's just a curved pl
 <Backdrop  
   :floor="1.5" 
   :segments="20" 
-  recieve-shadow>
+  receive-shadow>
     <TresMeshPhysicalMaterial color="orange" :roughness="1" />
 </Backdrop>
 ```


### PR DESCRIPTION
Fixed a typo for the `receive-shadow` prop of `<Backdrop>` in the Usage section. https://cientos.tresjs.org/guide/staging/backdrop.html#usage