### PR TITLE
docs: clean up demo line number highlights

### DIFF
--- a/docs/guide/abstractions/fbo.md
+++ b/docs/guide/abstractions/fbo.md
@@ -10,7 +10,7 @@ Cientos provides an `<Fbo />` component make it easy to use FBOs in your applica
 
 ## Usage
 
-<<< @/.vitepress/theme/components/FboDemo.vue{3,15,48,49,50,51,58}
+<<< @/.vitepress/theme/components/FboDemo.vue{3,15,48-51,58}
 
 ## Props
 

--- a/docs/guide/abstractions/use-fbo.md
+++ b/docs/guide/abstractions/use-fbo.md
@@ -16,7 +16,7 @@ The `useFBO` composable must be used inside of a child component since it needs 
 
 `FboCube.vue`
 
-<<< @/.vitepress/theme/components/FboCube.vue{2,4,5,6,7,8,9,10,11,20}
+<<< @/.vitepress/theme/components/FboCube.vue{2,4-11,20}
 
 `Experience.vue`
 

--- a/docs/guide/materials/custom-shader-material.md
+++ b/docs/guide/materials/custom-shader-material.md
@@ -8,7 +8,7 @@ The `cientos` package provides a new `<TresCustomShaderMaterial />` component wh
 
 ## Usage
 
-<<< @/.vitepress/theme/components/CustomShaderMaterialDemo.vue{4,9,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,59,60,99}
+<<< @/.vitepress/theme/components/CustomShaderMaterialDemo.vue{3,7,16-49,55-56,97}
 
 ## Props
 


### PR DESCRIPTION
## Problem

A few demos had line numbers written like this:

```
{2,4,5,6,7,8,9,10,11,20}
```

## Solution

Write them like this ...

```
{2,4-11,20}
```

... for easier readability/maintenance.

## Problem

The demo for materials/custom-shader-material had changed, but the line number highlights weren't updated.

## Solution

Update the line number highlights.