### PR TITLE
chore: add pre-push linter hook

### DIFF
--- a/.github/workflows/actions/pnpm/action.yml
+++ b/.github/workflows/actions/pnpm/action.yml
@@ -25,3 +25,8 @@ runs:
     - name: install dependencies
       run: pnpm install --shamefully-hoist
       shell: bash
+
+# Avoid running husky hooks on Github
+# http://typicode.github.io/husky/how-to.html
+env:
+  HUSKY: 0

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,7 @@
+// Skip Husky install in production and CI
+// http://typicode.github.io/husky/how-to.html
+if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
+  process.exit(0)
+}
+const husky = (await import('husky')).default
+console.log(husky())

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,25 @@
+# NOTE: Don't fail immediately after error
+# This allows us to echo messages even if the linter exits with an error.
+set +e  
+
+# NOTE: --silent to keep pnpm from echoing, e.g., "> @tresjs/core[...] lint" 
+# --max-warnings=0 to fail on errors *and* warnings
+pnpm --silent lint --max-warnings=0
+
+# NOTE: Capture linter exit status.
+LINT_STATUS=$?
+
+# NOTE: If linting failed, inform user how to proceed.
+if [[ $LINT_STATUS != 0 ]]; then
+  echo "
+To fix linter problems:
+  pnpm lint --fix  – fix automatically fixable problems
+  pnpm lint        – print a list of problems to fix by hand
+
+To skip this verification and push anyway (not recommended):
+  git push --no-verify <...>
+"
+fi
+
+# NOTE: +e was set, so we have to return an exit status.
+exit $LINT_STATUS

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.vue",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "prepare": "node .husky/install.mjs" 
   },
   "peerDependencies": {
     "@tresjs/core": ">=3.2",
@@ -78,6 +79,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-vue": "^9.21.1",
     "gsap": "^3.12.5",
+    "husky": "^9.0.11",
     "kolorist": "^1.8.0",
     "pathe": "^1.1.2",
     "release-it": "^17.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       gsap:
         specifier: ^3.12.5
         version: 3.12.5
+      husky:
+        specifier: ^9.0.11
+        version: 9.0.11
       kolorist:
         specifier: ^1.8.0
         version: 1.8.0
@@ -4599,6 +4602,12 @@ packages:
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+    dev: true
+
+  /husky@9.0.11:
+    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
+    engines: {node: '>=18'}
+    hasBin: true
     dev: true
 
   /iconv-lite@0.4.24:


### PR DESCRIPTION
Adds a Git pre-push hook that lints the project. 

* If there are linter errors/warnings:
  - the push is stopped
  - the errors/warnings are printed
  - an explanatory message is printed – see [.husky/pre-push](https://github.com/Tresjs/cientos/compare/chore/git-pre-push-lint?expand=1#diff-43bbc75a027a43baaddc57670d8ab49b4aa2981053c3cabba17567723d3a9fb6) in the commit
* If there are no linter errors/warnings, the push continues.

## Context

Discussed on TresJS: https://github.com/Tresjs/tres/issues/590

## Testing

You can run the hook without actually pushing if you ...

```
git push --dry-run <... extra args>
```

## Skipping

You can skip the hook during a push if you ...

```
git push --no-verify <... extra args>
```

(NOTE: This is mentioned in the console if linting fails.)

## Feedback?

@JaimeTorrealba @alvarosabu – What do you think?

