### PR TITLE
fix: camera controls ignored props

### DIFF
--- a/docs/guide/controls/camera-controls.md
+++ b/docs/guide/controls/camera-controls.md
@@ -26,35 +26,74 @@ Is really important that the Perspective camera is set first in the canvas. Othe
 
 Certainly! Here's the properties of the object in raw markdown table format:
 
-| Prop                      | Description                                                                                                                                                                               | Default             |
-| :------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| **makeDefault**           | Whether to make this the default controls.                                                                                                                                                | `false`             |
-| **camera**                | The camera to control.                                                                                                                                                                    | `undefined`         |
-| **domElement**            | The DOM element to listen to.                                                                                                                                                             | `undefined`         |
-| **minPolarAngle**         | Minimum vertical angle in radians.                                                                                                                                                        | `0`                 |
-| **maxPolarAngle**         | Maximum vertical angle in radians.                                                                                                                                                        | `Math.PI`           |
-| **minAzimuthAngle**       | Minimum horizontal angle in radians.                                                                                                                                                      | `-Infinity`         |
-| **maxAzimuthAngle**       | Maximum horizontal angle in radians.                                                                                                                                                      | `Infinity`          |
-| **distance**              | Current distance.                                                                                                                                                                         | `camera.position.z` |
-| **minDistance**           | Minimum distance for dolly. PerspectiveCamera only.                                                                                                                                       | `Number.EPSILON`    |
-| **maxDistance**           | Maximum distance for dolly. PerspectiveCamera only.                                                                                                                                       | `Infinity`          |
-| **infinityDolly**         | `true` to enable Infinity Dolly for wheel and pinch.                                                                                                                                      | `false`             |
-| **minZoom**               | Minimum camera zoom.                                                                                                                                                                      | `0.01`              |
-| **maxZoom**               | Maximum camera zoom.                                                                                                                                                                      | `Infinity`          |
-| **smoothTime**            | Approximate time in seconds to reach the target. A smaller value will reach the target faster.                                                                                            | `0.25`              |
-| **draggingSmoothTime**    | The smoothTime while dragging.                                                                                                                                                            | `0.125`             |
-| **maxSpeed**              | Max transition speed in units per second.                                                                                                                                                 | `Infinity`          |
-| **azimuthRotateSpeed**    | Speed of azimuth (horizontal) rotation.                                                                                                                                                   | `1.0`               |
-| **polarRotateSpeed**      | Speed of polar (vertical) rotation.                                                                                                                                                       | `1.0`               |
-| **dollySpeed**            | Speed of mouse-wheel dollying.                                                                                                                                                            | `1.0`               |
-| **dollyDragInverted**     | `true` to invert direction when dollying or zooming via drag.                                                                                                                             | `false`             |
-| **truckSpeed**            | Speed of drag for truck and pedestal.                                                                                                                                                     | `2.0`               |
-| **dollyToCursor**         | `true` to enable Dolly-in to the mouse cursor coords.                                                                                                                                     | `false`             |
-| **dragToOffset**          | Whether to drag to offset.                                                                                                                                                                | `false`             |
-| **verticalDragToForward** | The same as `.screenSpacePanning` in three.js's OrbitControls.                                                                                                                            | `false`             |
-| **boundaryFriction**      | Friction ratio of the boundary.                                                                                                                                                           | `0.0`               |
-| **restThreshold**         | Controls how soon the `rest` event fires as the camera slows.                                                                                                                             | `0.01`              |
-| **colliderMeshes**        | An array of Meshes to collide with the camera. Be aware colliderMeshes may decrease performance. The collision test uses 4 raycasters from the camera since the near plane has 4 corners. | `[]`                |
+| Prop                      | Description                                                                                                                                                                               | Default                                                   |
+| :------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| **makeDefault**           | Whether to make this the default controls.                                                                                                                                                | `false`                                                   |
+| **camera**                | The camera to control.                                                                                                                                                                    | `undefined`                                               |
+| **domElement**            | The DOM element to listen to.                                                                                                                                                             | `undefined`                                               |
+| **minPolarAngle**         | Minimum vertical angle in radians.                                                                                                                                                        | `0`                                                       |
+| **maxPolarAngle**         | Maximum vertical angle in radians.                                                                                                                                                        | `Math.PI`                                                 |
+| **minAzimuthAngle**       | Minimum horizontal angle in radians.                                                                                                                                                      | `-Infinity`                                               |
+| **maxAzimuthAngle**       | Maximum horizontal angle in radians.                                                                                                                                                      | `Infinity`                                                |
+| **distance**              | Current distance.                                                                                                                                                                         | `camera.position.z`                                       |
+| **minDistance**           | Minimum distance for dolly. PerspectiveCamera only.                                                                                                                                       | `Number.EPSILON`                                          |
+| **maxDistance**           | Maximum distance for dolly. PerspectiveCamera only.                                                                                                                                       | `Infinity`                                                |
+| **infinityDolly**         | `true` to enable Infinity Dolly for wheel and pinch.                                                                                                                                      | `false`                                                   |
+| **minZoom**               | Minimum camera zoom.                                                                                                                                                                      | `0.01`                                                    |
+| **maxZoom**               | Maximum camera zoom.                                                                                                                                                                      | `Infinity`                                                |
+| **smoothTime**            | Approximate time in seconds to reach the target. A smaller value will reach the target faster.                                                                                            | `0.25`                                                    |
+| **draggingSmoothTime**    | The smoothTime while dragging.                                                                                                                                                            | `0.125`                                                   |
+| **maxSpeed**              | Max transition speed in units per second.                                                                                                                                                 | `Infinity`                                                |
+| **azimuthRotateSpeed**    | Speed of azimuth (horizontal) rotation.                                                                                                                                                   | `1.0`                                                     |
+| **polarRotateSpeed**      | Speed of polar (vertical) rotation.                                                                                                                                                       | `1.0`                                                     |
+| **dollySpeed**            | Speed of mouse-wheel dollying.                                                                                                                                                            | `1.0`                                                     |
+| **dollyDragInverted**     | `true` to invert direction when dollying or zooming via drag.                                                                                                                             | `false`                                                   |
+| **truckSpeed**            | Speed of drag for truck and pedestal.                                                                                                                                                     | `2.0`                                                     |
+| **dollyToCursor**         | `true` to enable Dolly-in to the mouse cursor coords.                                                                                                                                     | `false`                                                   |
+| **dragToOffset**          | Whether to drag to offset.                                                                                                                                                                | `false`                                                   |
+| **verticalDragToForward** | The same as `.screenSpacePanning` in three.js's OrbitControls.                                                                                                                            | `false`                                                   |
+| **boundaryFriction**      | Friction ratio of the boundary.                                                                                                                                                           | `0.0`                                                     |
+| **restThreshold**         | Controls how soon the `rest` event fires as the camera slows.                                                                                                                             | `0.01`                                                    |
+| **colliderMeshes**        | An array of Meshes to collide with the camera. Be aware colliderMeshes may decrease performance. The collision test uses 4 raycasters from the camera since the near plane has 4 corners. | `[]`                                                      |
+| **mouseButtons**          | Configuration of actions on mouse input.                                                                                                                                                  | See [`User input config`](#user-input-config) for details |
+| **touches**               | Configuration of actions on touch.                                                                                                                                                        | See [`User input config`](#user-input-config) for details |
+
+## User input config
+
+You can easily override the default user input config by defining `mouseButtons` and/or `touches` props that correspond to [`camera-controls` settings](https://github.com/yomotsu/camera-controls?#user-input-config). For ease of use, we're re-exporting the `CameraControls` class as `CameraControlsClass` which gives you access to the `ACTION` enum.
+
+```vue
+<script lang="ts" setup>
+import { CameraControls, CameraControlsClass } from '@tresjs/cientos'
+</script>
+
+<template>
+  <CameraControls
+    :mouse-buttons="{ left: CameraControlsClass.ACTION.DOLLY, ... }"
+    :touches="{ one: CameraControlsClass.ACTION.TOUCH_TRUCK, ... }"
+  />
+</template>
+```
+
+### Mouse buttons
+
+| Button to assign        | Options                                                        | Default                                                         |
+| ----------------------- | -------------------------------------------------------------- | --------------------------------------------------------------- |
+| `mouseButtons.left`     | `ROTATE` \| `TRUCK` \| `OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE` | `ROTATE`                                                        |
+| `mouseButtons.right`    | `ROTATE` \| `TRUCK` \| `OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE` | `TRUCK`                                                         |
+| `mouseButtons.wheel` ¹  | `ROTATE` \| `TRUCK` \| `OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE` | `DOLLY` for Perspective camera, `ZOOM` for Orthographic camera. |
+| `mouseButtons.middle` ² | `ROTATE` \| `TRUCK` \| `OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE` | `DOLLY`                                                         |
+
+1. Mouse wheel event for scroll "up/down", on mac "up/down/left/right".
+2. Mouse wheel "button" click event.
+
+### Touches
+
+| Fingers to assign | Options                                                                                                                                                                                                                                 | Default                                                                                |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `touches.one`     | `TOUCH_ROTATE` \| `TOUCH_TRUCK` \| `TOUCH_OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE`                                                                                                                                                        | `TOUCH_ROTATE`                                                                         |
+| `touches.two`     | `TOUCH_DOLLY_TRUCK` \| `TOUCH_DOLLY_OFFSET` \| `TOUCH_DOLLY_ROTATE` \| `TOUCH_ZOOM_TRUCK` \| `TOUCH_ZOOM_OFFSET` \| `TOUCH_ZOOM_ROTATE` \| `TOUCH_DOLLY` \| `TOUCH_ZOOM` \| `TOUCH_ROTATE` \| `TOUCH_TRUCK` \| `TOUCH_OFFSET` \| `NONE` | `TOUCH_DOLLY_TRUCK` for Perspective camera, `TOUCH_ZOOM_TRUCK` for Othographic camera. |
+| `touches.three`   | `TOUCH_DOLLY_TRUCK` \| `TOUCH_DOLLY_OFFSET` \| `TOUCH_DOLLY_ROTATE` \| `TOUCH_ZOOM_TRUCK` \| `TOUCH_ZOOM_OFFSET` \| `TOUCH_ZOOM_ROTATE` \| `TOUCH_ROTATE` \| `TOUCH_TRUCK` \| `TOUCH_OFFSET` \| `NONE`                                  | `TOUCH_TRUCK`                                                                          |
 
 ## Events
 

--- a/docs/guide/controls/camera-controls.md
+++ b/docs/guide/controls/camera-controls.md
@@ -68,10 +68,12 @@ import { CameraControls, CameraControlsClass } from '@tresjs/cientos'
 </script>
 
 <template>
+  ...
   <CameraControls
-    :mouse-buttons="{ left: CameraControlsClass.ACTION.DOLLY, ... }"
-    :touches="{ one: CameraControlsClass.ACTION.TOUCH_TRUCK, ... }"
+    :mouse-buttons="{ left: CameraControlsClass.ACTION.DOLLY }"
+    :touches="{ one: CameraControlsClass.ACTION.TOUCH_TRUCK }"
   />
+  ...
 </template>
 ```
 

--- a/docs/guide/controls/camera-controls.md
+++ b/docs/guide/controls/camera-controls.md
@@ -60,18 +60,18 @@ Certainly! Here's the properties of the object in raw markdown table format:
 
 ## User input config
 
-You can easily override the default user input config by defining `mouseButtons` and/or `touches` props that correspond to [`camera-controls` settings](https://github.com/yomotsu/camera-controls?#user-input-config). For ease of use, we're re-exporting the `CameraControls` class as `CameraControlsClass` which gives you access to the `ACTION` enum.
+You can easily override the default user input config by defining `mouseButtons` and/or `touches` props that correspond to [`camera-controls` settings](https://github.com/yomotsu/camera-controls?#user-input-config). For ease of use, we're re-exporting the `CameraControls` class as `BaseCameraControls` which gives you access to the `ACTION` enum.
 
 ```vue
 <script lang="ts" setup>
-import { CameraControls, CameraControlsClass } from '@tresjs/cientos'
+import { CameraControls, BaseCameraControls } from '@tresjs/cientos'
 </script>
 
 <template>
   ...
   <CameraControls
-    :mouse-buttons="{ left: CameraControlsClass.ACTION.DOLLY }"
-    :touches="{ one: CameraControlsClass.ACTION.TOUCH_TRUCK }"
+    :mouse-buttons="{ left: BaseCameraControls.ACTION.DOLLY }"
+    :touches="{ one: BaseCameraControls.ACTION.TOUCH_TRUCK }"
   />
   ...
 </template>

--- a/src/core/controls/CameraControls.vue
+++ b/src/core/controls/CameraControls.vue
@@ -4,7 +4,9 @@ import { ref, watchEffect, onUnmounted, toRefs, computed } from 'vue'
 import type {
   PerspectiveCamera,
   OrthographicCamera,
-  Object3D } from 'three'
+  Object3D,
+  Camera,
+} from 'three'
 import {
   Box3,
   MathUtils,
@@ -19,6 +21,7 @@ import {
 } from 'three'
 import { useRenderLoop, useTresContext } from '@tresjs/core'
 import { useEventListener } from '@vueuse/core'
+import { isPerspectiveCamera, isOrthographicCamera } from '../../utils/types'
 
 export interface CameraControlsProps {
   /**
@@ -272,27 +275,38 @@ export interface CameraControlsProps {
   /**
    * User's mouse input config.
    *
+   * | Button to assign        | Options                                                        | Default                                                         |
+   * | ----------------------- | -------------------------------------------------------------- | --------------------------------------------------------------- |
+   * | `mouseButtons.left`     | `ROTATE` \| `TRUCK` \| `OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE` | `ROTATE`                                                        |
+   * | `mouseButtons.right`    | `ROTATE` \| `TRUCK` \| `OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE` | `TRUCK`                                                         |
+   * | `mouseButtons.wheel` ¹  | `ROTATE` \| `TRUCK` \| `OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE` | `DOLLY` for Perspective camera, `ZOOM` for Orthographic camera. |
+   * | `mouseButtons.middle` ² | `ROTATE` \| `TRUCK` \| `OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE` | `DOLLY`                                                         |
+   * 
+   * 1. Mouse wheel event for scroll "up/down", on mac "up/down/left/right".
+   * 2. Mouse wheel "button" click event.
+   *   
+   * > **_NOTE:_** `DOLLY` can't be set when camera is Orthographic.
+   * 
    * @default See description
    * @memberof CameraControlsProps
    */
-  mouseButtons?: {
-    left?: number
-    right?: number
-    wheel?: number
-    middle?: number
-  }
+  mouseButtons?: Partial<CameraControls['mouseButtons']>
 
   /**
    * User's touch input config.
-   *
+   * 
+   * | Fingers to assign | Options                                                                                                                                                                                                                                 | Default                                                                                |
+   * | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+   * | `touches.one`     | `TOUCH_ROTATE` \| `TOUCH_TRUCK` \| `TOUCH_OFFSET` \| `DOLLY` \| `ZOOM` \| `NONE`                                                                                                                                                        | `TOUCH_ROTATE`                                                                         |
+   * | `touches.two`     | `TOUCH_DOLLY_TRUCK` \| `TOUCH_DOLLY_OFFSET` \| `TOUCH_DOLLY_ROTATE` \| `TOUCH_ZOOM_TRUCK` \| `TOUCH_ZOOM_OFFSET` \| `TOUCH_ZOOM_ROTATE` \| `TOUCH_DOLLY` \| `TOUCH_ZOOM` \| `TOUCH_ROTATE` \| `TOUCH_TRUCK` \| `TOUCH_OFFSET` \| `NONE` | `TOUCH_DOLLY_TRUCK` for Perspective camera, `TOUCH_ZOOM_TRUCK` for Othographic camera. |
+   * | `touches.three`   | `TOUCH_DOLLY_TRUCK` \| `TOUCH_DOLLY_OFFSET` \| `TOUCH_DOLLY_ROTATE` \| `TOUCH_ZOOM_TRUCK` \| `TOUCH_ZOOM_OFFSET` \| `TOUCH_ZOOM_ROTATE` \| `TOUCH_ROTATE` \| `TOUCH_TRUCK` \| `TOUCH_OFFSET` \| `NONE`                                  | `TOUCH_TRUCK`                                                                          |
+   * 
+   * > **_NOTE:_** `TOUCH_DOLLY_TRUCK` and `TOUCH_DOLLY` can't be set when camera is Orthographic.
+   * 
    * @default See description
    * @memberof CameraControlsProps
    */
-  touches?: {
-    one?: number
-    two?: number
-    three?: number
-  }
+  touches?: Partial<CameraControls['touches']>
 }
 
 const props = withDefaults(defineProps<CameraControlsProps>(), {
@@ -321,8 +335,8 @@ const props = withDefaults(defineProps<CameraControlsProps>(), {
   boundaryFriction: 0.0,
   restThreshold: 0.01,
   colliderMeshes: () => [],
-  mouseButtons: () => defaultMouseButtons,
-  touches: () => defaultTouches,
+  mouseButtons: () => getMouseButtons(useTresContext().camera.value),
+  touches: () => getTouches(useTresContext().camera.value),
 })
 
 const emit = defineEmits(['change', 'start', 'end'])
@@ -357,16 +371,6 @@ const {
   touches: touchesRef,
 } = toRefs(props)
 
-const mouseButtons = computed(() => ({
-  ...defaultMouseButtons,
-  ...mouseButtonsRef.value,
-}))
-
-const touches = computed(() => ({
-  ...defaultTouches,
-  ...touchesRef.value,
-}))
-
 // allow for tree shaking, only importing required classes
 const subsetOfTHREE = {
   Box3,
@@ -385,6 +389,9 @@ const subsetOfTHREE = {
 CameraControls.install({ THREE: subsetOfTHREE })
 
 const { camera: activeCamera, renderer, extend, controls } = useTresContext()
+
+const mouseButtons = computed(() => getMouseButtons(activeCamera.value, mouseButtonsRef.value))
+const touches = computed(() => getTouches(activeCamera.value, touchesRef.value))
 
 const controlsRef = ref<CameraControls | null>(null)
 extend({ CameraControls })
@@ -423,18 +430,40 @@ defineExpose({
 </script>
 
 <script lang="ts">
-const defaultMouseButtons: CameraControls['mouseButtons'] = {
+const getMouseButtons = (
+  camera?: Camera,
+  mouseButtons?: Partial<CameraControls['mouseButtons']>,
+): CameraControls['mouseButtons'] => ({
   left: CameraControls.ACTION.ROTATE,
   middle: CameraControls.ACTION.DOLLY,
   right: CameraControls.ACTION.TRUCK,
-  wheel: CameraControls.ACTION.DOLLY,
-}
+  wheel: (
+    isPerspectiveCamera(camera)
+      ? CameraControls.ACTION.DOLLY
+      : isOrthographicCamera(camera)
+        ? CameraControls.ACTION.ZOOM
+        : CameraControls.ACTION.NONE
+  ),
+  ...mouseButtons,
+})
 
-const defaultTouches: CameraControls['touches'] = {
+const getTouches = (
+  camera?: Camera,
+  touches?: Partial<CameraControls['touches']>,
+): CameraControls['touches'] => ({
   one: CameraControls.ACTION.TOUCH_ROTATE,
-  two: CameraControls.ACTION.TOUCH_DOLLY_TRUCK,
+  two: (
+    isPerspectiveCamera(camera)
+      ? CameraControls.ACTION.TOUCH_DOLLY_TRUCK
+      : isOrthographicCamera(camera)
+        ? CameraControls.ACTION.TOUCH_ZOOM_TRUCK
+        : CameraControls.ACTION.NONE
+  ),
   three: CameraControls.ACTION.TOUCH_TRUCK,
-}
+  ...touches,
+})
+
+export { default as CameraControlsClass } from 'camera-controls'
 </script>
 
 <template>

--- a/src/core/controls/CameraControls.vue
+++ b/src/core/controls/CameraControls.vue
@@ -467,7 +467,7 @@ const getTouches = (
   ...touches,
 })
 
-export { default as CameraControlsClass } from 'camera-controls'
+export { default as BaseCameraControls } from 'camera-controls'
 </script>
 
 <template>

--- a/src/core/controls/CameraControls.vue
+++ b/src/core/controls/CameraControls.vue
@@ -367,8 +367,6 @@ const {
   boundaryFriction,
   restThreshold,
   colliderMeshes,
-  mouseButtons: mouseButtonsRef,
-  touches: touchesRef,
 } = toRefs(props)
 
 // allow for tree shaking, only importing required classes
@@ -390,8 +388,14 @@ CameraControls.install({ THREE: subsetOfTHREE })
 
 const { camera: activeCamera, renderer, extend, controls } = useTresContext()
 
-const mouseButtons = computed(() => getMouseButtons(activeCamera.value, mouseButtonsRef.value))
-const touches = computed(() => getTouches(activeCamera.value, touchesRef.value))
+const mouseButtons = computed(() => getMouseButtons(
+  props.camera || activeCamera.value,
+  props.mouseButtons,
+))
+const touches = computed(() => getTouches(
+  props.camera || activeCamera.value,
+  props.touches,
+))
 
 const controlsRef = ref<CameraControls | null>(null)
 extend({ CameraControls })

--- a/src/core/controls/CameraControls.vue
+++ b/src/core/controls/CameraControls.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import CameraControls from 'camera-controls'
-import { ref, watchEffect, onUnmounted, toRefs } from 'vue'
+import { ref, watchEffect, onUnmounted, toRefs, computed } from 'vue'
 import type {
   PerspectiveCamera,
   OrthographicCamera,
@@ -321,9 +321,8 @@ const props = withDefaults(defineProps<CameraControlsProps>(), {
   boundaryFriction: 0.0,
   restThreshold: 0.01,
   colliderMeshes: () => [],
-  // FIXME: set default values for mouseButtons and touches
-  // mouseButtons: {},
-  // touches: {}
+  mouseButtons: () => defaultMouseButtons,
+  touches: () => defaultTouches,
 })
 
 const emit = defineEmits(['change', 'start', 'end'])
@@ -354,7 +353,19 @@ const {
   boundaryFriction,
   restThreshold,
   colliderMeshes,
+  mouseButtons: mouseButtonsRef,
+  touches: touchesRef,
 } = toRefs(props)
+
+const mouseButtons = computed(() => ({
+  ...defaultMouseButtons,
+  ...mouseButtonsRef.value,
+}))
+
+const touches = computed(() => ({
+  ...defaultTouches,
+  ...touchesRef.value,
+}))
 
 // allow for tree shaking, only importing required classes
 const subsetOfTHREE = {
@@ -411,6 +422,21 @@ defineExpose({
 })
 </script>
 
+<script lang="ts">
+const defaultMouseButtons: CameraControls['mouseButtons'] = {
+  left: CameraControls.ACTION.ROTATE,
+  middle: CameraControls.ACTION.DOLLY,
+  right: CameraControls.ACTION.TRUCK,
+  wheel: CameraControls.ACTION.DOLLY,
+}
+
+const defaultTouches: CameraControls['touches'] = {
+  one: CameraControls.ACTION.TOUCH_ROTATE,
+  two: CameraControls.ACTION.TOUCH_DOLLY_TRUCK,
+  three: CameraControls.ACTION.TOUCH_TRUCK,
+}
+</script>
+
 <template>
   <TresCameraControls
     v-if="(camera || activeCamera) && (domElement || renderer)"
@@ -440,5 +466,7 @@ defineExpose({
     :rest-threshold="restThreshold"
     :collider-meshes="colliderMeshes"
     :args="[camera || activeCamera, domElement || renderer.domElement]"
+    :mouse-buttons="mouseButtons"
+    :touches="touches"
   />
 </template>

--- a/src/core/controls/index.ts
+++ b/src/core/controls/index.ts
@@ -4,7 +4,7 @@ import TransformControls from './TransformControls.vue'
 import PointerLockControls from './PointerLockControls.vue'
 import MapControls from './MapControls.vue'
 import ScrollControls from './ScrollControls.vue'
-import CameraControls, { CameraControlsClass } from './CameraControls.vue'
+import CameraControls, { BaseCameraControls } from './CameraControls.vue'
 
 export {
   OrbitControls,
@@ -14,5 +14,5 @@ export {
   KeyboardControls,
   ScrollControls,
   CameraControls,
-  CameraControlsClass,
+  BaseCameraControls,
 }

--- a/src/core/controls/index.ts
+++ b/src/core/controls/index.ts
@@ -4,7 +4,7 @@ import TransformControls from './TransformControls.vue'
 import PointerLockControls from './PointerLockControls.vue'
 import MapControls from './MapControls.vue'
 import ScrollControls from './ScrollControls.vue'
-import CameraControls from './CameraControls.vue'
+import CameraControls, { CameraControlsClass } from './CameraControls.vue'
 
 export {
   OrbitControls,
@@ -14,4 +14,5 @@ export {
   KeyboardControls,
   ScrollControls,
   CameraControls,
+  CameraControlsClass,
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,7 @@
+import type { Camera, OrthographicCamera, PerspectiveCamera } from 'three'
+
+export const isPerspectiveCamera = (camera?: Camera): camera is PerspectiveCamera =>
+  Boolean(camera && (camera as PerspectiveCamera).isPerspectiveCamera)
+
+export const isOrthographicCamera = (camera?: Camera): camera is OrthographicCamera =>
+  Boolean(camera && (camera as OrthographicCamera).isOrthographicCamera)


### PR DESCRIPTION
- Fixes https://github.com/Tresjs/cientos/issues/384
- Adds support for `mouseButtons` and `touches` prop.
- Adds default `mouseButtons` and `touches` prop values based on https://yomotsu.github.io/camera-controls/examples/config.html
- Adds support for partial overrides of `mouseButtons` and `touches`.
- Updates documentation of `CameraControls`
---
Feel free to point out at any mistakes and discrepancies from conventions. I have a strong React background, and some aspects of Vue are kinda new to me 😜 