### PR TITLE
chore(lightformer): remove defineProps import

### DIFF
--- a/src/core/staging/useEnvironment/lightformer/index.vue
+++ b/src/core/staging/useEnvironment/lightformer/index.vue
@@ -4,7 +4,7 @@
 ** https://github.com/pmndrs/drei/blob/master/src/core/Lightformer.tsx
 ** The Lightformer component in drei provides functionality for creating light probes in a scene.
 */
-import { defineProps, ref, watchEffect } from 'vue'
+import { ref, watchEffect } from 'vue'
 import type { MeshBasicMaterial, Texture } from 'three'
 import { Color, DoubleSide } from 'three'
 


### PR DESCRIPTION
## Problem

`defineProps` is `import`ed into `src/core/staging/useEnvironment/lightformer/index.vue`. [It's a macro](https://vuejs.org/guide/components/props.html#props-declaration), so it doesn't need to be imported.

The import is causing this warning while running the playground:

<img width="672" alt="Screenshot 2024-05-02 at 02 26 29" src="https://github.com/Tresjs/cientos/assets/20469369/a42f3785-8602-4c82-b0ba-9e12363fbaec">

## Solution

Remove the `defineProps` import.

## Context

At the moment, the CI step is failing all PRs because `main` contains linter errors. The file touched by this PR passes the linter.