### PR TITLE
refactor(Levioso): make speed prop optional

### DIFF
--- a/src/core/abstractions/Levioso.vue
+++ b/src/core/abstractions/Levioso.vue
@@ -5,7 +5,7 @@ import { shallowRef } from 'vue'
 
 const props = withDefaults(
   defineProps<{
-    speed: number
+    speed?: number
     rotationFactor?: number
     floatFactor?: number
     range?: [number, number]


### PR DESCRIPTION
## Problem

`<Levioso />` has a `speed` prop. The component sets a default value for the prop, but the prop itself isn't marked as optional in the props defintion.

## Solution

Mark the prop as optional.