### PR TITLE
chore: guard against overzealous md/jsdoc linting

### DIFF
--- a/src/core/staging/Fit.vue
+++ b/src/core/staging/Fit.vue
@@ -6,13 +6,13 @@ import { Box3, Group, Vector3 } from 'three'
 export interface Props {
   /**
    * If `into` is:
-   * omitted or explicitly `undefined`: position/scale children to fit into a 1 × 1 × 1 `Box3` at world origin.
-   * `null`: turn off `<Fit />`; reset scale/position of children.
-   * `number`: convert argument to `Vector3(number, number, number)`.
-   * `[number, number, number]`: convert argument to `Vector3`.
-   * `Vector3`: position/scale children to fit inside a `Box3` of size `Vector3` at target objects' cumulative center.
-   * `Box3`: position/scale children to fit inside `Box3`.
-   * `Object3D`: position/scale children to fit inside calculated `Box3`. [See `THREE.Box3.setFromObject`](https://threejs.org/docs/#api/en/math/Box3.setFromObject). `<Fit />` must not contain the `Object3D` and vice-versa.
+   * - omitted or explicitly `undefined`: position/scale children to fit into a 1 × 1 × 1 `Box3` at world origin.
+   * - `null`: turn off `<Fit />`; reset scale/position of children.
+   * - `number`: convert argument to `Vector3(number, number, number)`.
+   * - `[number, number, number]`: convert argument to `Vector3`.
+   * - `Vector3`: position/scale children to fit inside a `Box3` of size `Vector3` at target objects' cumulative center.
+   * - `Box3`: position/scale children to fit inside `Box3`.
+   * - `Object3D`: position/scale children to fit inside calculated `Box3`. [See `THREE.Box3.setFromObject`](https://threejs.org/docs/#api/en/math/Box3.setFromObject). `<Fit />` must not contain the `Object3D` and vice-versa.
    */
   into?: number | [number, number, number] | Vector3 | Box3 | Object3D | null
   /** [See `precise` argument in `THREE.Box3.setFromObject`](https://threejs.org/docs/index.html?q=box3#api/en/math/Box3.setFromObject) */

--- a/src/core/staging/Sparkles/component.vue
+++ b/src/core/staging/Sparkles/component.vue
@@ -28,9 +28,9 @@ interface SparkleProps {
   /**
    * Vertices of the geometry will be used to emit sparkles. Geometry normals are used for sparkles' traveling direction and for responding to the directional light prop.
    *
-   * If provided, the component will use the passed geometry.
-   * If no geometry is provided, the component will try to make a copy of the parent object's geometry.
-   * If no parent geometry exists, the component will create and use an IcosphereGeometry.
+   * - If provided, the component will use the passed geometry.
+   * - If no geometry is provided, the component will try to make a copy of the parent object's geometry.
+   * - If no parent geometry exists, the component will create and use an IcosphereGeometry.
    */
   geometry?: Object3D | BufferGeometry
   /**


### PR DESCRIPTION
## Problem

The new linter rules remove markdown formatting in some circumstances. #398

## Solution

For the affected text, change:

```
/**
 * * list item 1
 * * list item 2
 **/
```

to: 

```
/**
 * - list item 1
 * - list item 2
 **/
```