### PR TITLE
feat(cientos): local mouseparallax 

### DIFF
--- a/docs/guide/abstractions/mouse-parallax.md
+++ b/docs/guide/abstractions/mouse-parallax.md
@@ -18,9 +18,9 @@ You only need to import it and add it to your template as `<MouseParallax />`. A
 
 ## Props
 
-| Prop         | Description                        | Default |
-| :----------- | :--------------------------------- | ------- |
-| **disabled** | Enable or disable the effect       | false   |
-| **factor**   | Increase the range of the parallax | 2.5     |
-| **ease**     | Increase the camera movement speed | 0.1     |
-| **local**    | Enable movements locally           | false   |
+| Prop         | Description                                                                 | Default |
+| :----------- | :-------------------------------------------------------------------------- | ------- |
+| **disabled** | Enable or disable the effect                                                | false   |
+| **factor**   | Increase the range of the parallax                                          | 2.5     |
+| **ease**     | Increase the camera movement speed                                          | 0.1     |
+| **local**    | Whether the mouse coordinates are calculated from the element or the window | false   |

--- a/docs/guide/abstractions/mouse-parallax.md
+++ b/docs/guide/abstractions/mouse-parallax.md
@@ -12,12 +12,15 @@ You only need to import it and add it to your template as `<MouseParallax />`. A
 
 `factor` is a number to increase the movement range of the camera. `ease` is a number that smoothes the movement. You can also disable the effect with the `disabled` prop.
 
+`local` is a boolean that enables movement based on the position of the mouse on the element rather than the window.
+
 <<< @/.vitepress/theme/components/MouseParallaxDemo.vue{3,15-18}
 
 ## Props
 
-| Prop         | Description                                             | Default |
-| :----------- | :------------------------------------------------------ | ------- |
-| **disabled** | Enable or disable the effect                            | false   |
-| **factor**   | Increase the range of the parallax                      | 2.5     |
-| **ease**     | Increase the camera movement speed                      | 0.1     |
+| Prop         | Description                        | Default |
+| :----------- | :--------------------------------- | ------- |
+| **disabled** | Enable or disable the effect       | false   |
+| **factor**   | Increase the range of the parallax | 2.5     |
+| **ease**     | Increase the camera movement speed | 0.1     |
+| **local**    | Enable movements locally           | false   |

--- a/playground/src/pages/abstractions/MouseParallaxDemo.vue
+++ b/playground/src/pages/abstractions/MouseParallaxDemo.vue
@@ -27,4 +27,17 @@ const gl = {
     <MouseParallax :factor="3" />
     <TresAmbientLight :intensity="1" />
   </TresCanvas>
+  <TresCanvas v-bind="gl">
+    <TresPerspectiveCamera
+      :position="[0, 0, 7.5]"
+      :fov="75"
+      :near="0.1"
+      :far="1000"
+    />
+    <TorusKnot>
+      <TresMeshNormalMaterial />
+    </TorusKnot>
+    <MouseParallax :factor="3" local />
+    <TresAmbientLight :intensity="1" />
+  </TresCanvas>
 </template>

--- a/src/core/abstractions/MouseParallax.vue
+++ b/src/core/abstractions/MouseParallax.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, ref, toRefs, watch } from "vue";
-import type { Group } from "three";
-import { useRenderLoop, useTresContext } from "@tresjs/core";
-import { useElementSize, useMouse, useWindowSize } from "@vueuse/core";
-import type { UseMouseOptions } from "@vueuse/core";
+import { computed, ref, toRefs, watch } from 'vue'
+import type { Group } from 'three'
+import { useRenderLoop, useTresContext } from '@tresjs/core'
+import { useElementSize, useMouse, useWindowSize } from '@vueuse/core'
+import type { UseMouseOptions } from '@vueuse/core'
 
 export interface MouseParallaxProps {
   /**
@@ -13,7 +13,7 @@ export interface MouseParallaxProps {
    * @memberof MouseParallaxProps
    *
    */
-  disabled?: boolean;
+  disabled?: boolean
   /**
    * The factor to multiply the mouse movement by.
    * @type {number}
@@ -21,7 +21,7 @@ export interface MouseParallaxProps {
    * @memberof MouseParallaxProps
    *
    */
-  factor?: number;
+  factor?: number
   /**
    * The factor to smooth the mouse movement by.
    * @type {number}
@@ -29,7 +29,7 @@ export interface MouseParallaxProps {
    * @memberof MouseParallaxProps
    *
    */
-  ease?: number;
+  ease?: number
   /**
    * Whether to apply the parallax effect to the local canvas.
    * @type {boolean}
@@ -37,7 +37,7 @@ export interface MouseParallaxProps {
    * @memberof MouseParallaxProps
    *
    */
-  local?: boolean;
+  local?: boolean
 }
 
 const props = withDefaults(defineProps<MouseParallaxProps>(), {
@@ -45,50 +45,50 @@ const props = withDefaults(defineProps<MouseParallaxProps>(), {
   factor: 2.5,
   ease: 0.1,
   local: false,
-});
+})
 
-const { camera, renderer } = useTresContext();
+const { camera, renderer } = useTresContext()
 
-const { disabled, factor, ease, local } = toRefs(props);
+const { disabled, factor, ease, local } = toRefs(props)
 
-const mouseOptions: UseMouseOptions = {};
+const mouseOptions: UseMouseOptions = {}
 
 if (local.value) {
-  mouseOptions.target = renderer.value.domElement;
-  mouseOptions.type = "client";
+  mouseOptions.target = renderer.value.domElement
+  mouseOptions.type = 'client'
 }
 
-const { x, y } = useMouse(mouseOptions);
+const { x, y } = useMouse(mouseOptions)
 const { width, height } = local.value
   ? useElementSize(renderer.value.domElement)
-  : useWindowSize();
+  : useWindowSize()
 
-const cameraGroupRef = ref<Group>();
+const cameraGroupRef = ref<Group>()
 
-const cursorX = computed(() => (x.value / width.value - 0.5) * factor.value);
-const cursorY = computed(() => -(y.value / height.value - 0.5) * factor.value);
+const cursorX = computed(() => (x.value / width.value - 0.5) * factor.value)
+const cursorY = computed(() => -(y.value / height.value - 0.5) * factor.value)
 
-const { onLoop } = useRenderLoop();
+const { onLoop } = useRenderLoop()
 
 onLoop(({ delta }) => {
   if (
-    disabled.value ||
-    !cameraGroupRef.value ||
-    Number.isNaN(cursorX.value) ||
-    Number.isNaN(cursorY.value)
+    disabled.value
+    || !cameraGroupRef.value
+    || Number.isNaN(cursorX.value)
+    || Number.isNaN(cursorY.value)
   ) {
-    return;
+    return
   }
-  cameraGroupRef.value.position.x +=
-    (cursorX.value - cameraGroupRef.value.position.x) * ease.value * delta;
-  cameraGroupRef.value.position.y +=
-    (cursorY.value - cameraGroupRef.value.position.y) * ease.value * delta;
-});
+  cameraGroupRef.value.position.x
+    += (cursorX.value - cameraGroupRef.value.position.x) * ease.value * delta
+  cameraGroupRef.value.position.y
+    += (cursorY.value - cameraGroupRef.value.position.y) * ease.value * delta
+})
 
 watch(
   () => cameraGroupRef.value,
-  (value) => value?.add(camera.value)
-);
+  value => value?.add(camera.value),
+)
 </script>
 
 <template>

--- a/src/core/abstractions/MouseParallax.vue
+++ b/src/core/abstractions/MouseParallax.vue
@@ -2,7 +2,8 @@
 import { computed, ref, toRefs, watch } from 'vue'
 import type { Group } from 'three'
 import { useRenderLoop, useTresContext } from '@tresjs/core'
-import { useMouse, useWindowSize } from '@vueuse/core'
+import { useElementSize, useMouse, useWindowSize } from '@vueuse/core'
+import type { UseMouseOptions } from '@vueuse/core'
 
 export interface MouseParallaxProps {
   /**
@@ -29,20 +30,38 @@ export interface MouseParallaxProps {
    *
    */
   ease?: number
+  /**
+   * Whether to apply the parallax effect to the local canvas.
+   * @type {boolean}
+   * @default false
+   * @memberof MouseParallaxProps
+   *
+   */
+  local?: boolean
 }
 
 const props = withDefaults(defineProps<MouseParallaxProps>(), {
   disabled: false,
   factor: 2.5,
   ease: 0.1,
+  local: false,
 })
 
-const { camera } = useTresContext()
+const { camera, renderer } = useTresContext()
 
-const { disabled, factor, ease } = toRefs(props)
+const { disabled, factor, ease, local } = toRefs(props)
 
-const { x, y } = useMouse()
-const { width, height } = useWindowSize()
+const mouseOptions: UseMouseOptions = {}
+
+if (local.value) {
+  mouseOptions.target = renderer.value.domElement
+  mouseOptions.type = 'client'
+}
+
+const { x, y } = useMouse(mouseOptions)
+const { width, height } = local.value
+  ? useElementSize(renderer.value.domElement)
+  : useWindowSize()
 
 const cameraGroupRef = ref<Group>()
 
@@ -52,9 +71,18 @@ const cursorY = computed(() => -(y.value / height.value - 0.5) * factor.value)
 const { onLoop } = useRenderLoop()
 
 onLoop(({ delta }) => {
-  if (disabled.value || !cameraGroupRef.value) { return }
-  cameraGroupRef.value.position.x += (cursorX.value - cameraGroupRef.value.position.x) * ease.value * delta
-  cameraGroupRef.value.position.y += (cursorY.value - cameraGroupRef.value.position.y) * ease.value * delta
+  if (
+    disabled.value
+    || !cameraGroupRef.value
+    || Number.isNaN(cursorX.value)
+    || Number.isNaN(cursorY.value)
+  ) {
+    return
+  }
+  cameraGroupRef.value.position.x
+    += (cursorX.value - cameraGroupRef.value.position.x) * ease.value * delta
+  cameraGroupRef.value.position.y
+    += (cursorY.value - cameraGroupRef.value.position.y) * ease.value * delta
 })
 
 watch(

--- a/src/core/abstractions/MouseParallax.vue
+++ b/src/core/abstractions/MouseParallax.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, ref, toRefs, watch } from 'vue'
-import type { Group } from 'three'
-import { useRenderLoop, useTresContext } from '@tresjs/core'
-import { useElementSize, useMouse, useWindowSize } from '@vueuse/core'
-import type { UseMouseOptions } from '@vueuse/core'
+import { computed, ref, toRefs, watch } from "vue";
+import type { Group } from "three";
+import { useRenderLoop, useTresContext } from "@tresjs/core";
+import { useElementSize, useMouse, useWindowSize } from "@vueuse/core";
+import type { UseMouseOptions } from "@vueuse/core";
 
 export interface MouseParallaxProps {
   /**
@@ -13,7 +13,7 @@ export interface MouseParallaxProps {
    * @memberof MouseParallaxProps
    *
    */
-  disabled?: boolean
+  disabled?: boolean;
   /**
    * The factor to multiply the mouse movement by.
    * @type {number}
@@ -21,15 +21,15 @@ export interface MouseParallaxProps {
    * @memberof MouseParallaxProps
    *
    */
-  factor?: number
+  factor?: number;
   /**
-   * The factor to multiply the mouse movement by.
+   * The factor to smooth the mouse movement by.
    * @type {number}
    * @default 2.5
    * @memberof MouseParallaxProps
    *
    */
-  ease?: number
+  ease?: number;
   /**
    * Whether to apply the parallax effect to the local canvas.
    * @type {boolean}
@@ -37,7 +37,7 @@ export interface MouseParallaxProps {
    * @memberof MouseParallaxProps
    *
    */
-  local?: boolean
+  local?: boolean;
 }
 
 const props = withDefaults(defineProps<MouseParallaxProps>(), {
@@ -45,50 +45,50 @@ const props = withDefaults(defineProps<MouseParallaxProps>(), {
   factor: 2.5,
   ease: 0.1,
   local: false,
-})
+});
 
-const { camera, renderer } = useTresContext()
+const { camera, renderer } = useTresContext();
 
-const { disabled, factor, ease, local } = toRefs(props)
+const { disabled, factor, ease, local } = toRefs(props);
 
-const mouseOptions: UseMouseOptions = {}
+const mouseOptions: UseMouseOptions = {};
 
 if (local.value) {
-  mouseOptions.target = renderer.value.domElement
-  mouseOptions.type = 'client'
+  mouseOptions.target = renderer.value.domElement;
+  mouseOptions.type = "client";
 }
 
-const { x, y } = useMouse(mouseOptions)
+const { x, y } = useMouse(mouseOptions);
 const { width, height } = local.value
   ? useElementSize(renderer.value.domElement)
-  : useWindowSize()
+  : useWindowSize();
 
-const cameraGroupRef = ref<Group>()
+const cameraGroupRef = ref<Group>();
 
-const cursorX = computed(() => (x.value / width.value - 0.5) * factor.value)
-const cursorY = computed(() => -(y.value / height.value - 0.5) * factor.value)
+const cursorX = computed(() => (x.value / width.value - 0.5) * factor.value);
+const cursorY = computed(() => -(y.value / height.value - 0.5) * factor.value);
 
-const { onLoop } = useRenderLoop()
+const { onLoop } = useRenderLoop();
 
 onLoop(({ delta }) => {
   if (
-    disabled.value
-    || !cameraGroupRef.value
-    || Number.isNaN(cursorX.value)
-    || Number.isNaN(cursorY.value)
+    disabled.value ||
+    !cameraGroupRef.value ||
+    Number.isNaN(cursorX.value) ||
+    Number.isNaN(cursorY.value)
   ) {
-    return
+    return;
   }
-  cameraGroupRef.value.position.x
-    += (cursorX.value - cameraGroupRef.value.position.x) * ease.value * delta
-  cameraGroupRef.value.position.y
-    += (cursorY.value - cameraGroupRef.value.position.y) * ease.value * delta
-})
+  cameraGroupRef.value.position.x +=
+    (cursorX.value - cameraGroupRef.value.position.x) * ease.value * delta;
+  cameraGroupRef.value.position.y +=
+    (cursorY.value - cameraGroupRef.value.position.y) * ease.value * delta;
+});
 
 watch(
   () => cameraGroupRef.value,
-  value => value?.add(camera.value),
-)
+  (value) => value?.add(camera.value)
+);
 </script>
 
 <template>


### PR DESCRIPTION
This is an add to the props of the `MouseParallax`component.
If the prop `local` is set to true, the mouse coordinates and the `width` and `height` are calculated locally from the canvas, not from the window.