### PR TITLE
fix: 432 async draco loader

### DIFF
--- a/src/core/loaders/useGLTF/index.ts
+++ b/src/core/loaders/useGLTF/index.ts
@@ -26,6 +26,13 @@ export interface GLTFResult {
   scene: THREE.Scene
 }
 
+/**
+ * Create the loader for Draco.
+ *
+ * @param {string} decoderPath
+ * @return {*}
+ */
+
 async function createDRACOLoader(decoderPath: string): Promise<DRACOLoader> {
   const dracoLoader = new DRACOLoader()
   dracoLoader.setDecoderPath(decoderPath)


### PR DESCRIPTION
This fix #432, wrapping `new DRACOLoader()` in an async function to prevent racing condition, e.g. while looping through an array of models with draco compression.