### PR TITLE
fix(types): `useGLTF` `materials` should be type `THREE.MeshStandardMaterial`

### DIFF
--- a/src/core/loaders/useGLTF/index.ts
+++ b/src/core/loaders/useGLTF/index.ts
@@ -22,7 +22,7 @@ export interface GLTFLoaderOptions {
 export interface GLTFResult {
   animations: Array<THREE.AnimationClip>
   nodes: Record<string, TresObject3D>
-  materials: Record<string, THREE.Material>
+  materials: Record<string, THREE.MeshStandardMaterial>
   scene: THREE.Scene
 }
 


### PR DESCRIPTION
The type of `materials` object returned by `useGLTF` is supposed to be `Record<string, THREE.Material>` but when I inspect it it is actually `Record<string, THREE.MeshStandardMaterial>`.