### PR TITLE
chore(lint): reformat to avoid linter error

### DIFF
--- a/src/core/staging/ContactShadows.vue
+++ b/src/core/staging/ContactShadows.vue
@@ -310,12 +310,11 @@ function setColors(ps: typeof props, pool: ReturnType<typeof init>) {
   pool.depthMaterial.onBeforeCompile = function (shader) {
     const tint = ps.tint ? new Color(ps.tint as ColorRepresentation) : new Color('white')
     const { r, g, b } = tint
-    shader.fragmentShader = /* glsl */`
-    ${shader.fragmentShader.replace(
-        'gl_FragColor = vec4( vec3( 1.0 - fragCoordZ ), opacity );',
-        `gl_FragColor = vec4( ${r}, ${g}, ${b}, ( 1.0 - fragCoordZ ) * opacity);`,
-      )}
-    `
+    const fragmentShader = shader.fragmentShader.replace(
+      'gl_FragColor = vec4( vec3( 1.0 - fragCoordZ ), opacity );',
+      `gl_FragColor = vec4( ${r}, ${g}, ${b}, ( 1.0 - fragCoordZ ) * opacity);`,
+    )
+    shader.fragmentShader = fragmentShader
   }
 }
 


### PR DESCRIPTION
## Problem

The CI linter throws on code generated by the local linter. The code in question is an oddly formatted statement.

## Solution

Rewrite the oddly formatted statement more simply.