### PR TITLE
fix(MeshReflectionMaterial): remove unneeded material.onBeforeRender

### DIFF
--- a/src/core/materials/meshReflectionMaterial/index.vue
+++ b/src/core/materials/meshReflectionMaterial/index.vue
@@ -314,12 +314,6 @@ watch(() => [
   })
 }, { immediate: true })
 
-watch(materialRef, () => {
-  if (materialRef.value) {
-    materialRef.value.onBeforeRender = onBeforeRender
-  }
-})
-
 // NOTE: Begin #615 warning
 // The Tres core doesn't currently swap mesh materials when a
 // material component recompiles.


### PR DESCRIPTION
## Problem

`<MeshReflectionMaterial />` throws whenever it's included in a scene. 

The local `onBeforeRender` function in the file is called by the material, but the call doesn't send the arguments in the expected order.

## Solution

It's not necessary for `onBeforeRender` to be called by the material, since it's called during `useLoop().onBeforeRender()`.

Removed the call by the material.