### PR TITLE
fix(docs): remove Environment demo, fix links

### DIFF
--- a/docs/.vitepress/theme/components/EnvironmentDemo.vue
+++ b/docs/.vitepress/theme/components/EnvironmentDemo.vue
@@ -64,13 +64,8 @@ const { progress, hasFinishLoading } = await useProgress()
         :background="background.value"
         :files="environmentFiles"
         :blur="blur.value"
-        path="https://raw.githubusercontent.com/Tresjs/assets/main/textures/environmentMap"
+        path="https://raw.githubusercontent.com/Tresjs/assets/refs/heads/main/textures/environmentMap/"
       />
-      <!-- <Environment
-        :background="background.value"
-        :blur="blur.value"
-        preset="sunset"
-      /> -->
     </Suspense>
     <Sphere>
       <TresMeshStandardMaterial

--- a/docs/guide/staging/environment.md
+++ b/docs/guide/staging/environment.md
@@ -67,10 +67,6 @@ You can use one of the available presets by passing the `preset` prop:
 <Environment preset="city" />
 ```
 
-<DocsDemo>
-  <EnvironmentPresetsDemo/>
-</DocsDemo>
-
 ## Lightformer
 
 You can incorporate `Lightformer` into the environment just like a slot.
@@ -85,7 +81,8 @@ You can incorporate `Lightformer` into the environment just like a slot.
     <Lightformer :intensity="0.75" :position="[0, 5, -9]" />
     <Lightformer from="ring" :rotation-y="-Math.PI / 2" :scale="[10, 10, 1]" />
   </Environment>
-</template>
+</template>
+
 ```
 
 ### Props for Lightformer


### PR DESCRIPTION
## Problem

* Github links to images were bringing up a 404.
* `useProgress` does not appear to work if multiple demos are on a single page.

## Solution

* Update links
* Remove second demo from docs page at http://localhost:5173/guide/staging/environment.html

Closes #391