### PR TITLE
fix: 432 async draco loader

### DIFF
--- a/src/core/loaders/useGLTF/index.ts
+++ b/src/core/loaders/useGLTF/index.ts
@@ -83,6 +83,12 @@ export interface GLTFResult {
   scene: Scene
 }
 
+/**
+ * Create the loader for Draco.
+ *
+ * @param {string} decoderPath
+ * @return {*}
+ */
 function createDRACOLoader(decoderPath: string): DRACOLoader {
   const dracoLoader = new DRACOLoader()
   dracoLoader.setDecoderPath(decoderPath)


### PR DESCRIPTION
This is a rebase of #433 which also makes the createDRACOLoader a sync function. The important point, I believe, is to not share `dracoLoader` accross `useGLTF` as it can get disposed while `useLoader` needs it.