### PR TITLE
feat: 616-adapt-code-to-core-ctx-renderer-state-breaking-change

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "^10.0.0",
-    "@tresjs/core": "5.0.0-next.0",
+    "@tresjs/core": "https://pkg.pr.new/@tresjs/core@ff35bfc",
     "@tresjs/eslint-config": "^1.4.0",
     "@types/node": "^22.10.5",
     "@types/three": "^0.172.0",

--- a/playground/vue/package.json
+++ b/playground/vue/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tresjs/core": "5.0.0-next.0",
     "vue-router": "^4.5.0"
   },
   "devDependencies": {

--- a/playground/vue/src/pages/shapes/ScreenQuadDemo.vue
+++ b/playground/vue/src/pages/shapes/ScreenQuadDemo.vue
@@ -40,8 +40,8 @@ const mat = new RawShaderMaterial({
 
 let r: WebGLRenderer
 function onReady({ renderer }) {
-  r = renderer.value
-  renderer.value.getDrawingBufferSize(resolution)
+  r = renderer.instance.value
+  renderer.instance.value.getDrawingBufferSize(resolution)
   target.setSize(resolution.x, resolution.y)
   mat.uniforms.uResolution.value = resolution
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.0.0)(release-it@18.1.1(@types/node@22.13.11)(typescript@5.7.2))
       '@tresjs/core':
-        specifier: 5.0.0-next.0
-        version: 5.0.0-next.0(three@0.173.0)(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))
+        specifier: https://pkg.pr.new/@tresjs/core@ff35bfc
+        version: https://pkg.pr.new/@tresjs/core@ff35bfc(three@0.173.0)(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))
       '@tresjs/eslint-config':
         specifier: ^1.4.0
         version: 1.4.0(@typescript-eslint/utils@8.27.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.7.2))(@vue/compiler-sfc@3.5.13)(eslint@9.23.0(jiti@2.4.2))(typescript@5.7.2)
@@ -127,9 +127,6 @@ importers:
 
   playground/vue:
     dependencies:
-      '@tresjs/core':
-        specifier: 5.0.0-next.0
-        version: 5.0.0-next.0(three@0.173.0)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
       vue-router:
         specifier: ^4.5.0
         version: 4.5.0(vue@3.5.13(typescript@5.8.2))
@@ -1537,8 +1534,9 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@tresjs/core@5.0.0-next.0':
-    resolution: {integrity: sha512-AQom0UlFudxhlVpKaSjivF+8OpgZUdHsy/LxQ4VwUMJyGhqaVQfkb/og/5PLG45tdu8bNiklk8noQfEGL6ba9g==}
+  '@tresjs/core@https://pkg.pr.new/@tresjs/core@ff35bfc':
+    resolution: {tarball: https://pkg.pr.new/@tresjs/core@ff35bfc}
+    version: 5.0.0-next.0
     peerDependencies:
       three: '>=0.133'
       vue: '>=3.4'
@@ -6121,23 +6119,13 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@tresjs/core@5.0.0-next.0(three@0.173.0)(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))':
+  '@tresjs/core@https://pkg.pr.new/@tresjs/core@ff35bfc(three@0.173.0)(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@alvarosabu/utils': 3.2.0
       '@vue/devtools-api': 7.7.2
       '@vueuse/core': 12.8.2(typescript@5.7.2)
       three: 0.173.0
       vue: 3.5.13(typescript@5.7.2)
-    transitivePeerDependencies:
-      - typescript
-
-  '@tresjs/core@5.0.0-next.0(three@0.173.0)(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))':
-    dependencies:
-      '@alvarosabu/utils': 3.2.0
-      '@vue/devtools-api': 7.7.2
-      '@vueuse/core': 12.8.2(typescript@5.8.2)
-      three: 0.173.0
-      vue: 3.5.13(typescript@5.8.2)
     transitivePeerDependencies:
       - typescript
 
@@ -6883,6 +6871,7 @@ snapshots:
       vue: 3.5.13(typescript@5.8.2)
     transitivePeerDependencies:
       - typescript
+    optional: true
 
   '@vueuse/integrations@11.3.0(focus-trap@7.6.2)(vue@3.5.13(typescript@5.7.2))':
     dependencies:
@@ -6926,6 +6915,7 @@ snapshots:
       vue: 3.5.13(typescript@5.8.2)
     transitivePeerDependencies:
       - typescript
+    optional: true
 
   '@webgpu/types@0.1.51': {}
 

--- a/src/core/abstractions/AnimatedSprite/component.vue
+++ b/src/core/abstractions/AnimatedSprite/component.vue
@@ -76,10 +76,12 @@ const emit = defineEmits<{
   (e: 'loop', frameName: string): void
 }>()
 
-const { invalidate } = useTresContext()
+const { renderer } = useTresContext()
 
 watch(props, () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 })
 
 const positionX = ref(0)

--- a/src/core/abstractions/CubeCamera/useCubeCamera.ts
+++ b/src/core/abstractions/CubeCamera/useCubeCamera.ts
@@ -24,7 +24,7 @@ export interface CubeCameraOptions {
 
 export function useCubeCamera(props: CubeCameraOptions) {
   let { resolution, renderer, scene, envMap, fog, near, far } = props
-  renderer = renderer ?? useTres().renderer
+  renderer = renderer ?? useTres().renderer.instance
   scene = scene ?? useTres().scene
 
   const updateProps = () => {

--- a/src/core/abstractions/GlobalAudio.ts
+++ b/src/core/abstractions/GlobalAudio.ts
@@ -91,7 +91,7 @@ export const GlobalAudio = defineComponent<AudioProps>({
     }, { immediate: true })
 
     const selector = document.getElementById(props.playTrigger ?? '')
-    const btnPlay = selector || renderer.value.domElement
+    const btnPlay = selector || renderer.instance.value.domElement
     useEventListener(btnPlay, 'click', () => {
       if (sound.isPlaying) {
         sound.pause()

--- a/src/core/abstractions/Levioso.vue
+++ b/src/core/abstractions/Levioso.vue
@@ -33,7 +33,7 @@ defineExpose({
   const { onBeforeRender } = useLoop()
   let elapsed = START_OFFSET
 
-  onBeforeRender(({ delta, invalidate }) => {
+  onBeforeRender(({ delta /* invalidate */ }) => {
     if (!groupRef.value) { return }
 
     elapsed += delta * props.speed
@@ -45,7 +45,8 @@ defineExpose({
     group.rotation.z = Math.sin(theta) * AMPLITUDE_ROTATION_Z * props.rotationFactor
     group.position.y = MathUtils.mapLinear(Math.sin(theta), -1, 1, props.range[0], props.range[1]) * props.floatFactor
 
-    invalidate()
+    // TODO: comment this until invalidate is back in the loop callback on v5
+    // invalidate()
   })
 }
 </script>

--- a/src/core/abstractions/MouseParallax.vue
+++ b/src/core/abstractions/MouseParallax.vue
@@ -54,13 +54,13 @@ const { disabled, factor, ease, local } = toRefs(props)
 const mouseOptions: UseMouseOptions = {}
 
 if (local.value) {
-  mouseOptions.target = renderer.value.domElement
+  mouseOptions.target = renderer.instance.value.domElement
   mouseOptions.type = 'client'
 }
 
 const { x, y } = useMouse(mouseOptions)
 const { width, height } = local.value
-  ? useElementSize(renderer.value.domElement)
+  ? useElementSize(renderer.instance.value.domElement)
   : useWindowSize()
 
 const cameraGroupRef = shallowRef<Group>()
@@ -81,7 +81,7 @@ const cursorY = computed(() => -(y.value / height.value - 0.5) * _factor.value[1
 
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ delta, invalidate }) => {
+onBeforeRender(({ delta /* invalidate */ }) => {
   if (
     disabled.value
     || !cameraGroupRef.value
@@ -95,7 +95,8 @@ onBeforeRender(({ delta, invalidate }) => {
   cameraGroupRef.value.position.y
     += (cursorY.value - cameraGroupRef.value.position.y) * _ease.value[1] * delta
 
-  invalidate()
+  // TODO: comment this until invalidate is back in the loop callback on v5
+  // invalidate()
 })
 
 watch(

--- a/src/core/abstractions/Reflector.vue
+++ b/src/core/abstractions/Reflector.vue
@@ -72,7 +72,7 @@ const props = withDefaults(defineProps<ReflectorProps>(), {
   shader: Reflector.ReflectorShader,
 })
 
-const { extend, invalidate } = useTresContext()
+const { extend, renderer } = useTresContext()
 
 const reflectorRef = shallowRef<Reflector>()
 
@@ -81,7 +81,11 @@ extend({ Reflector })
 const { color, textureWidth, textureHeight, clipBias, multisample, shader }
   = toRefs(props)
 
-watch(props, () => invalidate())
+watch(props, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 defineExpose({
   instance: reflectorRef,

--- a/src/core/abstractions/Text3D.vue
+++ b/src/core/abstractions/Text3D.vue
@@ -151,9 +151,13 @@ const {
   bevelSegments,
 } = toRefs(props)
 
-const { extend, invalidate } = useTresContext()
+const { extend, renderer } = useTresContext()
 
-watch(props, () => invalidate())
+watch(props, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 extend({ TextGeometry })
 

--- a/src/core/abstractions/useFBO/index.ts
+++ b/src/core/abstractions/useFBO/index.ts
@@ -56,7 +56,7 @@ export function useFBO(options: FboOptions) {
   const { height, width, settings, depth, autoRender = ref(true) } = isReactive(options) ? toRefs(options) : toRefs(reactive(options))
 
   const { onBeforeRender } = useLoop()
-  const { camera, renderer, scene, sizes, invalidate } = useTresContext()
+  const { camera, renderer, scene, sizes } = useTresContext()
 
   watch(() => [width?.value, sizes.width.value, height?.value, sizes.height.value], () => {
     target.value?.dispose()
@@ -76,16 +76,18 @@ export function useFBO(options: FboOptions) {
       )
     }
 
-    invalidate()
+    if (renderer.canBeInvalidated.value) {
+      renderer.invalidate()
+    }
   }, { immediate: true })
 
   onBeforeRender(() => {
     if (autoRender.value) {
-      renderer.value.setRenderTarget(target.value)
-      renderer.value.clear()
-      renderer.value.render(scene.value, camera.value as Camera)
+      renderer.instance.value.setRenderTarget(target.value)
+      renderer.instance.value.clear()
+      renderer.instance.value.render(scene.value, camera.value as Camera)
 
-      renderer.value.setRenderTarget(null)
+      renderer.instance.value.setRenderTarget(null)
     }
   }, Number.POSITIVE_INFINITY)
 

--- a/src/core/abstractions/useSurfaceSampler/component.vue
+++ b/src/core/abstractions/useSurfaceSampler/component.vue
@@ -11,9 +11,13 @@ const samplerRef = ref()
 const instancedRef = ref()
 const meshToSampleRef = ref()
 
-const { invalidate } = useTresContext()
+const { renderer } = useTresContext()
 
-watch(props, () => invalidate())
+watch(props, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 // TODO: refactor to use watch instead.
 watchEffect(() => {

--- a/src/core/controls/MapControls.vue
+++ b/src/core/controls/MapControls.vue
@@ -2,7 +2,7 @@
 import { useLoop, useTresContext } from '@tresjs/core'
 import { useEventListener } from '@vueuse/core'
 import { MapControls } from 'three-stdlib'
-import { onUnmounted, shallowRef, toRefs, watch } from 'vue'
+import { computed, onUnmounted, shallowRef, toRefs, watch } from 'vue'
 import type { TresVector3 } from '@tresjs/core'
 import type { Camera } from 'three'
 
@@ -275,10 +275,14 @@ const {
   rotateSpeed,
 } = toRefs(props)
 
-const { camera: activeCamera, renderer, extend, controls, invalidate } = useTresContext()
+const { camera: activeCamera, renderer, extend, controls } = useTresContext()
+
+const contextDomElement = computed(() => renderer.instance.value.domElement)
 
 watch(props, () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 })
 
 const controlsRef = shallowRef<MapControls | null>(null)
@@ -296,7 +300,9 @@ watch(controls, (value) => {
 
 function onChange() {
   addEventListeners()
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
   emit('change', controlsRef.value)
 }
 function addEventListeners() {
@@ -306,11 +312,12 @@ function addEventListeners() {
 }
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ invalidate }) => {
+onBeforeRender(() => {
   if (controlsRef.value && (enableDamping.value || autoRotate.value)) {
     controlsRef.value.update()
 
-    invalidate()
+    // TODO: comment this until invalidate is back in the loop callback on v5
+    // invalidate()
   }
 })
 
@@ -327,9 +334,9 @@ defineExpose({
 
 <template>
   <TresMapControls
-    v-if="(camera || activeCamera) && (domElement || renderer)"
+    v-if="(camera || activeCamera) && (domElement || contextDomElement)"
     ref="controlsRef"
-    :args="[camera || activeCamera, domElement || renderer.domElement]"
+    :args="[camera || activeCamera, domElement || contextDomElement]"
     :auto-rotate="autoRotate"
     :auto-rotate-speed="autoRotateSpeed"
     :enable-damping="enableDamping"

--- a/src/core/controls/ScrollControls.vue
+++ b/src/core/controls/ScrollControls.vue
@@ -68,10 +68,12 @@ const emit = defineEmits(['update:modelValue'])
 if (props.smoothScroll < 0) { logWarning('SmoothControl must be greater than zero') }
 if (props.pages < 0) { logWarning('Pages must be greater than zero') }
 
-const { camera, controls, renderer, invalidate } = useTresContext()
+const { camera, controls, renderer } = useTresContext()
 
 watch(props, () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 })
 const wrapperRef = shallowRef()
 const scrollContainer = document.createElement('div')
@@ -132,7 +134,7 @@ watch(containerX, (value) => {
 })
 
 watch(
-  renderer,
+  renderer.instance,
   (value) => {
     const canvas = value?.domElement
     if (props.htmlScroll && value?.domElement) {
@@ -190,7 +192,7 @@ watch(
 
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ invalidate }) => {
+onBeforeRender(() => {
   if (camera.value?.position) {
     const delta
       = (progress.value * props.distance - camera.value.position[direction] + initCameraPos) * props.smoothScroll
@@ -200,7 +202,8 @@ onBeforeRender(({ invalidate }) => {
       wrapperRef.value.position[direction] += delta
     }
 
-    invalidate()
+    // TODO: comment this until invalidate is back in the loop callback on v5
+    // invalidate()
   }
 })
 

--- a/src/core/controls/TransformControls.vue
+++ b/src/core/controls/TransformControls.vue
@@ -3,7 +3,7 @@ import { useTresContext } from '@tresjs/core'
 import { useEventListener } from '@vueuse/core'
 
 import { TransformControls } from 'three-stdlib'
-import { onUnmounted, shallowRef, toRefs, watch } from 'vue'
+import { computed, onUnmounted, shallowRef, toRefs, watch } from 'vue'
 import type { Camera, Event, Object3D } from 'three'
 
 export interface TransformControlsProps {
@@ -40,16 +40,22 @@ const { object, mode, enabled, axis, translationSnap, rotationSnap, scaleSnap, s
 
 const controlsRef = shallowRef<TransformControls | null>(null)
 
-const { controls, camera: activeCamera, renderer, extend, invalidate } = useTresContext()
+const { controls, camera: activeCamera, renderer, extend } = useTresContext()
+
+const domElement = computed(() => renderer.instance.value.domElement)
 
 watch([object, mode, enabled, axis, translationSnap, rotationSnap, scaleSnap, space, size, showX, showY, showZ], () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 })
 
 extend({ TransformControls })
 
 const onChange = () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
   emit('change')
 }
 
@@ -59,22 +65,30 @@ interface DraggingEvent extends Event {
 
 const onDragingChange = (e: DraggingEvent) => {
   if (controls.value) { controls.value.enabled = !(e).value }
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
   emit('dragging', e.value)
 }
 
 const onMouseDown = () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
   emit('mouseDown')
 }
 
 const onMouseUp = () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
   emit('mouseDown')
 }
 
 const onObjectChange = () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
   emit('objectChange')
 }
 
@@ -105,11 +119,11 @@ defineExpose({
 
 <template>
   <TresTransformControls
-    v-if="(camera || activeCamera) && renderer"
+    v-if="(camera || activeCamera) && domElement"
     ref="controlsRef"
     :key="(camera || activeCamera)?.uuid"
     :object="object"
-    :args="[camera || activeCamera, renderer.domElement]"
+    :args="[camera || activeCamera, domElement]"
     :mode="mode"
     :enabled="enabled"
     :axis="axis"

--- a/src/core/materials/customShaderMaterial/index.vue
+++ b/src/core/materials/customShaderMaterial/index.vue
@@ -16,9 +16,13 @@ const props = defineProps<CustomShaderMaterialProps>()
 
 const customShaderMaterialClass = shallowRef(null)
 
-const { extend, invalidate } = useTresContext()
+const { extend, renderer } = useTresContext()
 extend({ CustomShaderMaterial })
-watch(props, () => invalidate())
+watch(props, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 defineExpose({ instance: customShaderMaterialClass })
 </script>

--- a/src/core/materials/holographicMaterial/index.vue
+++ b/src/core/materials/holographicMaterial/index.vue
@@ -46,9 +46,10 @@ defineExpose({ root: MeshHolographicMaterialClass, constructor: HolographicMater
 
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ invalidate }) => {
+onBeforeRender(() => {
   MeshHolographicMaterialClass.value?.update()
-  invalidate()
+  // TODO: comment this until invalidate is back in the loop callback on v5
+  // invalidate()
 })
 </script>
 

--- a/src/core/materials/meshReflectionMaterial/index.vue
+++ b/src/core/materials/meshReflectionMaterial/index.vue
@@ -151,7 +151,7 @@ const props = withDefaults(
   },
 )
 
-const { extend, invalidate } = useTresContext()
+const { extend, renderer: tresRenderer } = useTresContext()
 extend({ MeshReflectionMaterial })
 
 const blurWidth = computed(() => 500 - (Array.isArray(props.blurSize) ? props.blurSize[0] : props.blurSize))
@@ -205,7 +205,9 @@ const fboBlur = new WebGLRenderTarget(
 )
 
 function onBeforeRender(renderer: WebGLRenderer, scene: Scene, camera: Camera, object: Object3D) {
-  invalidate()
+  if (tresRenderer.canBeInvalidated.value) {
+    tresRenderer.invalidate()
+  }
 
   const currentXrEnabled = renderer.xr.enabled
   const currentShadowAutoUpdate = renderer.shadowMap.autoUpdate
@@ -361,11 +363,13 @@ onBeforeUnmount(() => {
   blurpass.dispose()
 })
 
-useLoop().onBeforeRender(({ renderer, scene, camera, invalidate }) => {
+useLoop().onBeforeRender(({ renderer, scene, camera }) => {
   const parent = (materialRef.value as any)?.__tres?.parent
   if (!parent) { return }
   onBeforeRender(renderer, scene, camera, parent)
-  invalidate()
+  if (tresRenderer.canBeInvalidated.value) {
+    tresRenderer.invalidate()
+  }
 })
 defineExpose({ instance: materialRef })
 </script>

--- a/src/core/materials/meshWobbleMaterial/index.vue
+++ b/src/core/materials/meshWobbleMaterial/index.vue
@@ -17,18 +17,24 @@ const props = withDefaults(
 
 const materialRef = shallowRef()
 
-const { extend, invalidate } = useTresContext()
+const { extend, renderer } = useTresContext()
 
 extend({ MeshWobbleMaterial })
 
-watch(props, () => invalidate())
+watch(props, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ elapsed, invalidate }) => {
+onBeforeRender(({ elapsed }) => {
   if (materialRef.value) {
     materialRef.value.time = elapsed * props?.speed
-    invalidate()
+    if (renderer.canBeInvalidated.value) {
+      renderer.invalidate()
+    }
   }
 })
 

--- a/src/core/misc/BakeShadows.ts
+++ b/src/core/misc/BakeShadows.ts
@@ -8,8 +8,8 @@ export const BakeShadows = defineComponent({
     const { renderer } = useTresContext()
 
     watchEffect(() => {
-      renderer.value.shadowMap.autoUpdate = false
-      renderer.value.shadowMap.needsUpdate = true
+      renderer.instance.value.shadowMap.autoUpdate = false
+      renderer.instance.value.shadowMap.needsUpdate = true
     })
   },
 })

--- a/src/core/misc/StatsGl.ts
+++ b/src/core/misc/StatsGl.ts
@@ -101,7 +101,7 @@ export const StatsGl = defineComponent<StatsGlProps>({
 
     const { onAfterRender } = useLoop()
 
-    statsGl.init(renderer.value)
+    statsGl.init(renderer.instance.value)
 
     onAfterRender(() => statsGl.update(), Number.POSITIVE_INFINITY)
 

--- a/src/core/misc/html/HTML.vue
+++ b/src/core/misc/html/HTML.vue
@@ -166,7 +166,7 @@ watch(
 )
 
 watch(
-  () => [groupRef.value, renderer.value, sizes.width.value, sizes.height.value, slots.default?.()],
+  () => [groupRef.value, renderer.instance.value, sizes.width.value, sizes.height.value, slots.default?.()],
   ([group, renderer]): void => {
     if (group && renderer) {
       const target = portal?.value || renderer.domElement
@@ -222,10 +222,11 @@ const visible = ref(true)
 
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ invalidate }) => {
-  invalidate()
+onBeforeRender(() => {
+  // TODO: comment this until invalidate is back in the loop callback on v5
+  // invalidate()
 
-  if (groupRef.value && camera.value && renderer.value) {
+  if (groupRef.value && camera.value && renderer.instance.value) {
     camera.value?.updateMatrixWorld()
     groupRef.value.updateWorldMatrix(true, false)
 

--- a/src/core/shapes/Box.vue
+++ b/src/core/shapes/Box.vue
@@ -25,10 +25,14 @@ export interface BoxProps {
 }
 
 const props = withDefaults(defineProps<BoxProps>(), { args: () => [1, 1, 1], color: '#ffffff' })
-const { invalidate } = useTresContext()
+const { renderer } = useTresContext()
 
 const { args, color } = toRefs(props)
-watch(args, () => invalidate())
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const boxRef = shallowRef()
 

--- a/src/core/shapes/Circle.vue
+++ b/src/core/shapes/Circle.vue
@@ -24,8 +24,12 @@ export interface CircleProps {
 
 const props = withDefaults(defineProps<CircleProps>(), { args: () => [1, 32, 0, Math.PI * 2], color: '#ffffff' })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const circleRef = shallowRef()
 

--- a/src/core/shapes/Cone.vue
+++ b/src/core/shapes/Cone.vue
@@ -27,9 +27,12 @@ const props = withDefaults(defineProps<ConeProps>(), {
   color: '#ffffff',
 })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
-
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 const coneRef = shallowRef()
 
 defineExpose({

--- a/src/core/shapes/Cylinder.vue
+++ b/src/core/shapes/Cylinder.vue
@@ -27,8 +27,12 @@ const props = withDefaults(defineProps<CylinderProps>(), {
   color: '#ffffff',
 })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const cylinderRef = shallowRef()
 

--- a/src/core/shapes/Dodecahedron.vue
+++ b/src/core/shapes/Dodecahedron.vue
@@ -26,9 +26,12 @@ const props = withDefaults(defineProps<DodecahedronProps>(), { args: () => [1, 0
 const { args, color } = toRefs(props)
 
 const dodecahedronRef = shallowRef()
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
-
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 defineExpose({
   instance: dodecahedronRef,
 })

--- a/src/core/shapes/Icosahedron.vue
+++ b/src/core/shapes/Icosahedron.vue
@@ -24,9 +24,12 @@ export interface IcosahedronProps {
 
 const props = withDefaults(defineProps<IcosahedronProps>(), { args: () => [1, 0], color: '#ffffff' })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
-
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 const icosahedronRef = shallowRef()
 
 defineExpose({

--- a/src/core/shapes/Line2.vue
+++ b/src/core/shapes/Line2.vue
@@ -67,7 +67,7 @@ function getInterpolatedVertexColors(vertexColors: VertexColors | null, numPoint
 const lineMaterial = new LineMaterial()
 const lineGeometry = new LineGeometry()
 const line = new Line2(lineGeometry, lineMaterial)
-const { sizes, invalidate } = useTresContext()
+const { sizes, renderer } = useTresContext()
 const hasVertexColors = computed(() => Array.isArray(props.vertexColors))
 
 function updateLineMaterial(material: LineMaterial, props: PropsType) {
@@ -123,15 +123,21 @@ watch(() => [
   props.dashOffset,
 ], () => {
   updateLineMaterial(lineMaterial, props)
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 })
 watch(() => [props.points, props.vertexColors], () => {
   updateLineGeometry(lineGeometry, props.points, props.vertexColors)
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 })
 watch(() => [sizes.height, sizes.width], () => {
   lineMaterial.resolution = new Vector2(sizes.width.value, sizes.height.value)
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 })
 
 onUnmounted(() => {

--- a/src/core/shapes/Octahedron.vue
+++ b/src/core/shapes/Octahedron.vue
@@ -24,8 +24,12 @@ export interface OctahedronProps {
 
 const props = withDefaults(defineProps<OctahedronProps>(), { args: () => [1, 0], color: '#ffffff' })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const octahedronRef = shallowRef()
 

--- a/src/core/shapes/Plane.vue
+++ b/src/core/shapes/Plane.vue
@@ -25,8 +25,12 @@ export interface PlaneProps {
 const props = withDefaults(defineProps<PlaneProps>(), { args: () => [1, 1], color: '#ffffff' })
 
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const planeRef = shallowRef()
 

--- a/src/core/shapes/Ring.vue
+++ b/src/core/shapes/Ring.vue
@@ -25,9 +25,12 @@ export interface RingProps {
 const props = withDefaults(defineProps<RingProps>(), { args: () => [0.5, 1, 32], color: '#ffffff' })
 
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
-
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 const ringRef = shallowRef()
 
 defineExpose({

--- a/src/core/shapes/RoundedBox.vue
+++ b/src/core/shapes/RoundedBox.vue
@@ -29,10 +29,13 @@ export interface BoxProps {
 const props = withDefaults(defineProps<BoxProps>(), { args: () => [1, 1, 1, 2, 0.1], color: '#ffffff' })
 
 const { args, color } = toRefs(props)
-const { invalidate, extend } = useTresContext()
+const { renderer, extend } = useTresContext()
 extend({ RoundedBoxGeometry })
-watch(args, () => invalidate())
-
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 const roundedBoxRef = shallowRef()
 
 defineExpose({ instance: roundedBoxRef })

--- a/src/core/shapes/Sphere.vue
+++ b/src/core/shapes/Sphere.vue
@@ -25,9 +25,12 @@ export interface SphereProps {
 
 const props = withDefaults(defineProps<SphereProps>(), { args: () => [2, 32, 16], color: '#ffffff' })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
-
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 const sphereRef = shallowRef()
 
 defineExpose({

--- a/src/core/shapes/Superformula.vue
+++ b/src/core/shapes/Superformula.vue
@@ -47,7 +47,7 @@ const props = withDefaults(defineProps<SuperFormulaProps>(), {
   color: 'white',
 })
 
-const { invalidate } = useTresContext()
+const { renderer } = useTresContext()
 
 const { cos, sin, abs } = Math
 
@@ -127,7 +127,9 @@ watch(() => [props.widthSegments, props.heightSegments], () => {
     geometry.value.dispose()
   }
   geometry.value = makeGeometry(props.widthSegments, props.heightSegments)
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 }, { immediate: true })
 
 watch(() => [
@@ -141,7 +143,9 @@ watch(() => [
   props.expB[2],
 ], () => {
   updateGeometry(geometry.value, props.numArmsA, props.expA[0], props.expA[1], props.expA[2], props.numArmsB, props.expB[0], props.expB[1], props.expB[2], props.widthSegments, props.heightSegments)
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 }, { immediate: true })
 
 onUnmounted(() => {

--- a/src/core/shapes/Torus.vue
+++ b/src/core/shapes/Torus.vue
@@ -24,8 +24,12 @@ export interface TorusProps {
 
 const props = withDefaults(defineProps<TorusProps>(), { args: () => [1, 1, 16, 80], color: '#ffffff' })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const torusRef = shallowRef()
 

--- a/src/core/shapes/TorusKnot.vue
+++ b/src/core/shapes/TorusKnot.vue
@@ -24,8 +24,12 @@ export interface TorusKnotProps {
 
 const props = withDefaults(defineProps<TorusKnotProps>(), { args: () => [1, 0.4, 64, 8], color: '#ffffff' })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const torusKnotRef = shallowRef()
 

--- a/src/core/shapes/Tube.vue
+++ b/src/core/shapes/Tube.vue
@@ -35,8 +35,12 @@ const props = withDefaults(defineProps<TubeProps>(), {
   color: '#ffffff',
 })
 const { args, color } = toRefs(props)
-const { invalidate } = useTresContext()
-watch(args, () => invalidate())
+const { renderer } = useTresContext()
+watch(args, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const tubeRef = shallowRef()
 

--- a/src/core/staging/AccumulativeShadows/component.vue
+++ b/src/core/staging/AccumulativeShadows/component.vue
@@ -63,11 +63,11 @@ const props = withDefaults(defineProps<AccumulativeShadowsProps>(), {
 
 extend({ SoftShadowMaterial })
 
-const { renderer: gl, scene, camera, invalidate } = useTres()
+const { renderer, scene, camera } = useTres()
 const gOuter = shallowRef<Group>()
 const gPlane = shallowRef<Mesh<PlaneGeometry, SoftShadowMaterialProps & ShaderMaterial>>(null!)
 const gLights = shallowRef<Group>(new Group())
-const progressiveLightMap = computed(() => new ProgressiveLightMap(gl.value, scene.value, props.resolution))
+const progressiveLightMap = computed(() => new ProgressiveLightMap(renderer.instance.value, scene.value, props.resolution))
 const shadowMapTexture = shallowRef<Texture>()
 
 let frameCount = 0
@@ -141,13 +141,17 @@ useLoop().onBeforeRender(() => {
 
   if (props.accumulate && props.once) {
     if (frameCount < props.frames || frameCount < props.blend) {
-      invalidate()
+      if (renderer.canBeInvalidated.value) {
+        renderer.invalidate()
+      }
       update()
       frameCount++
     }
   }
   else {
-    invalidate()
+    if (renderer.canBeInvalidated.value) {
+      renderer.invalidate()
+    }
     if (frameCount < props.frames) {
       update(props.frames - frameCount)
       frameCount = props.frames

--- a/src/core/staging/Bounds/component.vue
+++ b/src/core/staging/Bounds/component.vue
@@ -47,7 +47,7 @@ const emit = defineEmits<{
   (e: 'end', sizeProps: OnLookAtCallbackArg): void
 }>()
 
-const { invalidate, camera, controls, sizes: size } = useTres()
+const { renderer, camera, controls, sizes: size } = useTres()
 const defaultEasing = (t: number) => 1 - (1 - t) ** 3
 
 const bounds = new Bounds(camera.value ?? new PerspectiveCamera())
@@ -61,12 +61,16 @@ const refresh = () => {
   bounds.duration = props.duration
   bounds.clip = props.clip
   bounds.lookAt()
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 }
 
 useLoop().onBeforeRender(({ delta }) => {
   if (bounds.animate(delta)) {
-    invalidate()
+    if (renderer.canBeInvalidated.value) {
+      renderer.invalidate()
+    }
   }
 })
 

--- a/src/core/staging/ContactShadows.vue
+++ b/src/core/staging/ContactShadows.vue
@@ -324,11 +324,12 @@ const pool = init(props)
 let count = 0
 const updateOnNextRender = () => count = count >= props.frames ? props.frames - 1 : count
 onBeforeRender(
-  ({ renderer, scene, invalidate }) => {
+  ({ renderer, scene /* invalidate */ }) => {
     if (count < props.frames) {
       count++
       update(props, scene, renderer, pool)
-      invalidate()
+      // TODO: comment this until invalidate is back in the loop callback on v5
+      // invalidate()
     }
   },
 )

--- a/src/core/staging/Fit.vue
+++ b/src/core/staging/Fit.vue
@@ -28,7 +28,7 @@ const props = withDefaults(
   },
 )
 
-const { invalidate } = useTresContext()
+const { renderer } = useTresContext()
 
 const middle = shallowRef<Group>(new Group())
 const inner = shallowRef<Group>(new Group())
@@ -85,7 +85,9 @@ function fit(container: typeof props.into, precise: typeof props.precise) {
     middle.value.position.copy(childBoxCenter.sub(childBoxCenter.multiplyScalar(scale)))
   }
 
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 }
 
 function normalizeContainer(container: typeof props.into, precise: typeof props.precise): IntoPropNormalized {

--- a/src/core/staging/Ocean.vue
+++ b/src/core/staging/Ocean.vue
@@ -153,9 +153,10 @@ normalMap.wrapS = normalMap.wrapT = RepeatWrapping
 
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ delta, invalidate }) => {
+onBeforeRender(({ delta /* invalidate */ }) => {
   waterRef.value.material.uniforms.time.value += delta
-  invalidate()
+  // TODO: comment this until invalidate is back in the loop callback on v5
+  // invalidate()
 })
 </script>
 

--- a/src/core/staging/Precipitation.vue
+++ b/src/core/staging/Precipitation.vue
@@ -206,7 +206,7 @@ watchEffect(async () => {
 
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ invalidate }) => {
+onBeforeRender(() => {
   if (geometryRef.value?.attributes.position.array && geometryRef.value?.attributes.position.count) {
     const positionArray = geometryRef.value.attributes.position.array
     for (let i = 0; i < geometryRef.value.attributes.position.count; i++) {
@@ -221,7 +221,8 @@ onBeforeRender(({ invalidate }) => {
     }
     geometryRef.value.attributes.position.needsUpdate = true
 
-    invalidate()
+    // TODO: comment this until invalidate is back in the loop callback on v5
+    // invalidate()
   }
 })
 

--- a/src/core/staging/Sky.vue
+++ b/src/core/staging/Sky.vue
@@ -47,9 +47,13 @@ const props = withDefaults(defineProps<SkyProps>(), {
   distance: 450000,
 })
 
-const { invalidate } = useTresContext()
+const { renderer } = useTresContext()
 
-watch(props, () => invalidate())
+watch(props, () => {
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
+})
 
 const skyRef = shallowRef<SkyImpl>()
 const skyImpl = new SkyImpl()

--- a/src/core/staging/Smoke.vue
+++ b/src/core/staging/Smoke.vue
@@ -104,17 +104,18 @@ const calculateOpacity = (scale: number, density: number): number => (scale / 6)
 const { map } = (await useTexture({ map: texture.value })) as { map: Texture }
 
 const { renderer, camera } = useTresContext()
-const colorSpace = computed(() => renderer.value?.outputColorSpace)
+const colorSpace = computed(() => renderer.instance.value?.outputColorSpace)
 
 const { onBeforeRender } = useLoop()
 
-onBeforeRender(({ invalidate }) => {
+onBeforeRender(() => {
   if (smokeRef.value && camera.value && groupRef.value) {
     groupRef.value?.children.forEach((child: Object3D, index: number) => {
       child.rotation.z += smoke[index].rotation
     })
     smokeRef.value.lookAt(camera.value?.position)
-    invalidate()
+    // TODO: comment this until invalidate is back in the loop callback on v5
+    // invalidate()
   }
 })
 </script>

--- a/src/core/staging/SoftShadows.vue
+++ b/src/core/staging/SoftShadows.vue
@@ -170,14 +170,14 @@ function reset(renderer: WebGLRenderer, scene: Scene, camera: Camera) {
 onUnmounted(() => {
   if (camera.value) {
     ShaderChunk.shadowmap_pars_fragment = originalShadowsFragment
-    reset(renderer.value, scene.value, camera.value)
+    reset(renderer.instance.value, scene.value, camera.value)
   }
 })
 
 watch(props, () => {
   if (camera.value) {
-    injectSoftShadowsFragment(renderer.value, props)
-    reset(renderer.value, scene.value, camera.value)
+    injectSoftShadowsFragment(renderer.instance.value, props)
+    reset(renderer.instance.value, scene.value, camera.value)
   }
 }, { immediate: true })
 </script>

--- a/src/core/staging/Sparkles/component.vue
+++ b/src/core/staging/Sparkles/component.vue
@@ -367,13 +367,14 @@ watch(refs.map, () => {
 
 const rotation = new Quaternion()
 const normal = new Vector3()
-useLoop().onBeforeRender(({ elapsed, invalidate }) => {
+useLoop().onBeforeRender(({ elapsed /* invalidate */ }) => {
   sparkles.getWorldQuaternion(rotation)
   normal.copy(props.directionalLight ? props.directionalLight.position : Object3D.DEFAULT_UP).normalize()
   normal.applyQuaternion(rotation.invert())
   mat.uniforms.uNormal.value = normal
   mat.uniforms.uTime.value = elapsed / (props.cooldownSec + props.lifetimeSec)
-  invalidate()
+  // TODO: comment this until invalidate is back in the loop callback on v5
+  // invalidate()
 })
 
 function isObject3D(o: any): o is Object3D {

--- a/src/core/staging/Stars.vue
+++ b/src/core/staging/Stars.vue
@@ -86,10 +86,12 @@ const scale = ref()
 
 const { radius, depth, count, size, sizeAttenuation, transparent, alphaMap, alphaTest } = toRefs(props)
 
-const { invalidate } = useTresContext()
+const { renderer } = useTresContext()
 
 watch(props, () => {
-  invalidate()
+  if (renderer.canBeInvalidated.value) {
+    renderer.invalidate()
+  }
 })
 
 const setStars = () => {

--- a/src/core/staging/useEnvironment/component.vue
+++ b/src/core/staging/useEnvironment/component.vue
@@ -35,16 +35,17 @@ const useEnvironmentTexture = await useEnvironment(props, fbo)
 
 const { onBeforeRender } = useLoop()
 let count = 1
+
 onBeforeRender(() => {
   if (cubeCamera && environmentScene.value && fbo.value) {
     if (props.frames === Number.POSITIVE_INFINITY || count < props.frames) {
       // Update cube camera
-      const autoClear = renderer.value.autoClear
-      renderer.value.autoClear = true
+      const autoClear = renderer.instance.value.autoClear
+      renderer.instance.value.autoClear = true
       // Use raw scene to avoid proxy issues
       const rawScene = toRaw(environmentScene.value).virtualScene
-      cubeCamera.update(renderer.value, rawScene)
-      renderer.value.autoClear = autoClear
+      cubeCamera.update(renderer.instance.value, rawScene)
+      renderer.instance.value.autoClear = autoClear
       count++
     }
   }

--- a/src/core/staging/useEnvironment/index.ts
+++ b/src/core/staging/useEnvironment/index.ts
@@ -36,7 +36,7 @@ export async function useEnvironment(
   options: Partial<EnvironmentOptions>,
   fbo: Ref<WebGLCubeRenderTarget | null>,
 ): Promise<Ref<Texture | CubeTexture | null>> {
-  const { scene, invalidate } = useTresContext()
+  const { scene, renderer } = useTresContext()
 
   const {
     preset,
@@ -47,7 +47,9 @@ export async function useEnvironment(
   } = toRefs(options)
 
   watch(options, () => {
-    invalidate()
+    if (renderer.canBeInvalidated.value) {
+      renderer.invalidate()
+    }
   })
 
   const texture: Ref<Texture | CubeTexture | null> = ref(null)
@@ -126,7 +128,9 @@ export async function useEnvironment(
       if (texture.value) {
         texture.value.mapping = EquirectangularReflectionMapping
       }
-      invalidate()
+      if (renderer.canBeInvalidated.value) {
+        renderer.invalidate()
+      }
     }
     else if (value && !(value in environmentPresets)) {
       throw new Error(`Preset must be one of: ${Object.keys(environmentPresets).join(', ')}`)


### PR DESCRIPTION
- Updated various components to access the renderer through `renderer.instance.value` instead of `renderer.value`, ensuring compatibility with the latest core changes.
- Adjusted related watch and invalidate calls to check for `renderer.canBeInvalidated.value` before invoking invalidate, improving performance and stability.
- Refactored multiple files including shapes, controls, and materials to reflect these changes, enhancing overall code consistency and maintainability.