### PR TITLE
fix: update Vite configuration for external dependencies

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,6 @@ export default defineConfig({
   },
   plugins: [
     vue({
-      isProduction: false,
       ...templateCompilerOptions,
     }),
     dts({
@@ -59,13 +58,19 @@ export default defineConfig({
           open: true,
         }), */
       ],
-      external: ['three', 'vue', '@tresjs/core'],
+      external: ['three', 'vue', '@tresjs/core', '@vueuse/core'],
       output: {
         exports: 'named',
+        globals: {
+          '@tresjs/core': 'TresjsCore',
+          'three': 'Three',
+          'vue': 'Vue',
+          '@vueuse/core': 'VueUseCore',
+        },
       },
     },
   },
   optimizeDeps: {
-    exclude: ['three', 'vue', '@tresjs/core'],
+    exclude: ['three', 'vue', '@tresjs/core', '@vueuse/core'],
   },
 })


### PR DESCRIPTION
- Removed the `isProduction` option from the Vue plugin configuration in `vite.config.ts` to streamline the setup.
- Added `@vueuse/core` to the external dependencies list, ensuring proper module resolution during the build process.
- Updated the output globals to include `@vueuse/core`, enhancing compatibility with the project's dependency management.