### PR TITLE
feat: add `traverse` option to model loaders

### DIFF
--- a/docs/guide/loaders/use-fbx.md
+++ b/docs/guide/loaders/use-fbx.md
@@ -54,6 +54,12 @@ import TheModel from './TheModel.vue'
 | **isLoading**| `boolean` | Whether the model is currently loading         |
 | **execute**  | `() => Promise<void>` | Function to reload the model |
 
+## Options
+
+| Name            | Type       | Description                                |
+| :-------------- | ---------- | ------------------------------------------ |
+| **traverse**    | `Function` | A traverse function applied to the scene upon loading the model. |
+
 ## Accessing Nodes and Materials
 
 The composable provides computed properties to easily access nodes and materials in your scene:

--- a/docs/guide/loaders/use-gltf.md
+++ b/docs/guide/loaders/use-gltf.md
@@ -65,10 +65,11 @@ const { state, nodes, materials } = useGLTF('/models/AkuAku.gltf', { draco: true
 
 ## Options
 
-| Name            | Type      | Default     | Description                          |
-| :-------------- | --------- | ----------- | ------------------------------------ |
-| **draco**       | `boolean` | `false`     | Whether to enable Draco compression. |
-| **decoderPath** | `string`  | `'https://www.gstatic.com/draco/versioned/decoders/1.5.6/'` | Path to the Draco decoder.     |
+| Name            | Type       | Default     | Description                          |
+| :-------------- | ---------- | ----------- | ------------------------------------ |
+| **draco**       | `boolean`  | `false`     | Whether to enable Draco compression. |
+| **decoderPath** | `string`   | `'https://www.gstatic.com/draco/versioned/decoders/1.5.6/'` | Path to the Draco decoder.     |
+| **traverse**    | `Function` |             | A traverse function applied to the scene upon loading the model. |
 
 ## Accessing Nodes and Materials
 

--- a/src/core/loaders/useFBX/index.ts
+++ b/src/core/loaders/useFBX/index.ts
@@ -4,14 +4,13 @@ import { buildGraph, useLoader } from '@tresjs/core'
 import { computed, type MaybeRef, watch } from 'vue'
 
 import { FBXLoader } from 'three-stdlib'
-import type { Object3D } from 'three'
 
 export interface UseFBXOptions {
   /**
    * A traverse function applied to the scene upon loading the model.
    * @type {Function}
    */
-  traverse?: (child: Object3D) => void
+  traverse?: (child: TresObject) => void
 }
 
 /**
@@ -34,7 +33,7 @@ export function useFBX(path: MaybeRef<string>, options?: UseFBXOptions) {
   if (options?.traverse) {
     watch(result.state, (state) => {
       // GLTF loader types aren't aligned with Three.js types
-      state.traverse(child => options.traverse?.(child as Object3D))
+      state.traverse(child => options.traverse?.(child as TresObject))
     })
   }
 

--- a/src/core/loaders/useFBX/index.ts
+++ b/src/core/loaders/useFBX/index.ts
@@ -32,7 +32,6 @@ export function useFBX(path: MaybeRef<string>, options?: UseFBXOptions) {
   const result = useLoader(FBXLoader, path)
   if (options?.traverse) {
     watch(result.state, (state) => {
-      // GLTF loader types aren't aligned with Three.js types
       state.traverse(child => options.traverse?.(child as TresObject))
     })
   }

--- a/src/core/loaders/useGLTF/component.vue
+++ b/src/core/loaders/useGLTF/component.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { watch } from 'vue'
-import { type Group, Mesh } from 'three'
+import { watchEffect } from 'vue'
+import { Mesh } from 'three'
 import { useGLTF } from '.'
 
 const props = withDefaults(
@@ -22,19 +22,15 @@ defineExpose({
   instance: state,
 })
 
-let modelObject: Group | null = null
-
-watch(state, (newVal) => {
-  if (newVal?.scene) {
-    modelObject = newVal.scene
-    if ((props.castShadow || props.receiveShadow) && modelObject) {
-      modelObject.traverse((child) => {
-        if (child instanceof Mesh) {
-          child.castShadow = props.castShadow
-          child.receiveShadow = props.receiveShadow
-        }
-      })
-    }
+// Apply shadow settings when the model loads or shadow props change
+watchEffect(() => {
+  if (state.value.scene && (props.castShadow || props.receiveShadow)) {
+    state.value.scene.traverse((child) => {
+      if (child instanceof Mesh) {
+        child.castShadow = props.castShadow
+        child.receiveShadow = props.receiveShadow
+      }
+    })
   }
 })
 </script>
@@ -96,8 +92,8 @@ export interface GLTFModelProps {
 
 <template>
   <primitive
-    v-if="!isLoading && modelObject"
-    :object="modelObject"
+    v-if="!isLoading && state.scene"
+    :object="state.scene"
     v-bind="$attrs"
   />
 </template>

--- a/src/core/loaders/useGLTF/index.ts
+++ b/src/core/loaders/useGLTF/index.ts
@@ -58,7 +58,6 @@ export function useGLTF(path: MaybeRef<string>, options?: UseGLTFOptions) {
   const result = useLoader(GLTFLoader, path, useLoaderOptions)
   if (options?.traverse) {
     watch(result.state, (state) => {
-      // GLTF loader types aren't aligned with Three.js types
       state.scene.traverse(child => options.traverse?.(child as TresObject))
     })
   }

--- a/src/core/loaders/useGLTF/index.ts
+++ b/src/core/loaders/useGLTF/index.ts
@@ -5,7 +5,6 @@ import { computed, type MaybeRef, watch } from 'vue'
 
 import type { GLTF } from 'three-stdlib'
 import { DRACOLoader, GLTFLoader } from 'three-stdlib'
-import type { Object3D } from 'three'
 
 export interface UseGLTFOptions {
   /**
@@ -22,7 +21,7 @@ export interface UseGLTFOptions {
    * A traverse function applied to the scene upon loading the model.
    * @type {Function}
    */
-  traverse?: (child: Object3D) => void
+  traverse?: (child: TresObject) => void
 }
 
 /**
@@ -60,7 +59,7 @@ export function useGLTF(path: MaybeRef<string>, options?: UseGLTFOptions) {
   if (options?.traverse) {
     watch(result.state, (state) => {
       // GLTF loader types aren't aligned with Three.js types
-      state.scene.traverse(child => options.traverse?.(child as Object3D))
+      state.scene.traverse(child => options.traverse?.(child as TresObject))
     })
   }
 


### PR DESCRIPTION
- Adds a `traverse` option to the `useFBX` and `useGLTF` composables to enable workflows like:
```ts
const { state } = useGLTF("/foo.gltf", {
  traverse(child) { /* ... */ }
})

// Instead of
const { state } = useGLTF("/foo.gltf")
watch(state, (state) => {
	state.scene.traverse((child) => { /* ... */ })
})
```
- Updates documentation to reflect the new `traverse` option.
- Aligns `GLTFModel` props behavior with `FBXModel`'s, shadow should be reactive now.

Let me know if anything! Also, I'm not suggesting this strongly and am completely open to suggestions! This just sparked up from a Discord convo with @alvarosabu.