### PR TITLE
feat: enhance `useAnimations` composable with manual update option

### DIFF
--- a/docs/guide/abstractions/use-animations.md
+++ b/docs/guide/abstractions/use-animations.md
@@ -1,10 +1,14 @@
 # useAnimations
 
-`useAnimation` is a composable that returns a `shallowReactive` with all the models actions based on the animations provided. It is a wrapper around the [AnimationMixer](https://threejs.org/docs/#api/en/animation/AnimationMixer) class.
+`useAnimations` is a composable that returns a `shallowReactive` with all the models actions based on the animations provided. It is a wrapper around the [AnimationMixer](https://threejs.org/docs/#api/en/animation/AnimationMixer) class.
 
 <StackBlitzEmbed projectId="tresjs-use-animations" />
 
 ## Usage
+
+### Basic Usage (Automatic Updates)
+
+By default, `useAnimations` automatically updates the animation mixer on each frame using the `useLoop` composable:
 
 ```ts
 import { useAnimations, useGLTF } from '@tresjs/cientos'
@@ -22,3 +26,37 @@ watch(actions, (newActions) => {
   currentAction.value.play()
 })
 ```
+
+### Manual Updates
+
+For more control over when the animation mixer updates, you can set `manualUpdate: true` and handle the updates yourself:
+
+```ts
+import { useAnimations, useGLTF } from '@tresjs/cientos'
+import { useLoop } from '@tresjs/core'
+
+const { state } = useGLTF('/models/ugly-naked-bunny.gltf')
+
+const animations = computed(() => state.value?.animations || [])
+const model = computed(() => state?.value?.scene)
+const { actions, mixer } = useAnimations(animations, model, {
+  manualUpdate: true,
+})
+
+// Handle updates manually
+const { onBeforeRender } = useLoop()
+onBeforeRender(({ delta }) => {
+  mixer.value.update(delta)
+})
+
+const currentAction = ref()
+
+watch(actions, (newActions) => {
+  currentAction.value = newActions.Greeting
+  currentAction.value.play()
+})
+```
+
+## Options
+
+- `manualUpdate` (optional): When set to `true`, disables automatic animation mixer updates. You'll need to call `mixer.value.update(delta)` manually. Default is `false`.

--- a/playground/vue/src/pages/abstractions/use-animations/TheModel.vue
+++ b/playground/vue/src/pages/abstractions/use-animations/TheModel.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
 import { useAnimations, useGLTF } from '@tresjs/cientos'
+import { useLoop } from '@tresjs/core'
 
 const { state } = useGLTF('https://raw.githubusercontent.com/Tresjs/assets/main/models/gltf/ugly-naked-bunny/ugly-naked-bunny-animated.gltf', { draco: true })
 
 const animations = computed(() => state.value?.animations || [])
 const model = computed(() => state?.value?.scene)
-const { actions } = useAnimations(animations, model)
+const { actions, mixer } = useAnimations(animations, model, {
+  manualUpdate: true,
+})
+
+const { onBeforeRender } = useLoop()
+
+onBeforeRender(({ delta }) => {
+  mixer.value.update(delta)
+})
 
 const currentAction = ref()
 


### PR DESCRIPTION
- Renamed `useAnimation` to `useAnimations` for consistency.
- Added support for manual updates in the `useAnimations` composable, allowing users to control when the animation mixer updates.
- Updated documentation to reflect the new manual update feature and provided usage examples.
- Adjusted the implementation to utilize a computed property for the `AnimationMixer`, ensuring proper reactive updates.

These changes improve flexibility and control over animations in the TresJS framework.