### PR TITLE
fix:emit the correct event on mouse up in TransformControls

### DIFF
--- a/src/core/controls/TransformControls.vue
+++ b/src/core/controls/TransformControls.vue
@@ -70,7 +70,7 @@ const onMouseDown = () => {
 
 const onMouseUp = () => {
   invalidate()
-  emit('mouseDown')
+  emit('mouseUp')
 }
 
 const onObjectChange = () => {


### PR DESCRIPTION
TransformControls has a typo and currently emits a mouseDown event instead of mouseUp when the mouse is released.